### PR TITLE
Chore: Adds dependency to copybara task

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,19 @@
+# Releasing
+
+We generate packages via the `package_goreleaser` evergreen task. This task runs off of main and is only triggered when a new tag is pushed.
+
+### Release Steps
+To manually generate a new stable release you can run:
+
+
+```bash
+git tag -a -s "v1.0.0" -m "v1.0.0"
+git push origin "v1.0.0"
+```
+
+**Note:** Please use the `vX.Y.Z` format for the version to release.
+
+This will do the following things:
+1. The [evergreen](build/ci/release.yml) release task will run after a tag event from main.
+2. If everything goes smoothly, the release will be published in the [releases page](https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases).
+3. The [evergreen](build/ci/release.yml) copybara task will automatically open a PR on docs repositories with any document changes for the docs team to review and merge. 

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -123,6 +123,9 @@ tasks:
       - func: "install gh-token"
       - func: "package"
   - name: copybara
+    depends_on:
+      - name: package_goreleaser
+        variant: release
     commands:
       - func: "build-copybara"
       - command: github.generate_token


### PR DESCRIPTION
## Proposed changes

Adds dependency to copybara task such that it will run after `package_goreleaser` task.
Adds RELEASING.md will guide on how to release a new version.

_Jira ticket:_ CLOUDP-296374

## Checklist
- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments