### PR TITLE
chore: Ports atlascli changes

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -257,7 +257,7 @@ tasks:
           MCLI_SERVICE: cloud
           E2E_TAGS: apply
   - name: atlas_kubernetes_install_e2e
-    tags: [ "e2e","generic","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
+    tags: [ "e2e","required","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
     must_have_test_results: true
     commands:
       - func: "install gotestsum"
@@ -279,14 +279,6 @@ buildvariants:
       <<: *go_linux_version
     tasks:
       - name: .code_health
-  - name: e2e_generic
-    display_name: "E2E Tests Generic"
-    run_on:
-      - rhel80-small
-    expansions:
-      <<: *go_linux_version
-    tasks:
-      - name: ".e2e .generic"
   - name: e2e_required
     display_name: "E2E Tests Required"
     run_on:

--- a/internal/kubernetes/operator/install.go
+++ b/internal/kubernetes/operator/install.go
@@ -28,6 +28,7 @@ import (
 	akov2common "github.com/mongodb/mongodb-atlas-kubernetes/v2/api/v1/common"
 	"go.mongodb.org/atlas-sdk/v20241113004/admin"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -150,7 +151,6 @@ func (i *Install) ensureProject(orgID, projectName string) (*admin.Group, error)
 		Group: &admin.Group{
 			Name:                      projectName,
 			OrgId:                     orgID,
-			RegionUsageRestrictions:   pointer.Get(""),
 			WithDefaultAlertsSettings: pointer.Get(true),
 		},
 	})
@@ -284,10 +284,17 @@ func (i *Install) ensureCredentialsAssignment(ctx context.Context) error {
 			}
 		}
 
-		project.Spec.ConnectionSecret = connectionSecret
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := i.kubectl.Get(ctx, client.ObjectKeyFromObject(&project), &project); err != nil {
+				return err
+			}
 
-		if err = i.kubectl.Update(ctx, &project); err != nil {
-			return fmt.Errorf("failed to update atlas project %s", i.projectName)
+			project.Spec.ConnectionSecret = connectionSecret
+
+			return i.kubectl.Update(ctx, &project)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to update atlas project %s: %w", i.projectName, err)
 		}
 	}
 

--- a/internal/kubernetes/operator/project/project.go
+++ b/internal/kubernetes/operator/project/project.go
@@ -184,7 +184,7 @@ func BuildAtlasProject(br *AtlasProjectBuildRequest) (*AtlasProjectResult, error
 	}
 
 	if br.Validator.FeatureExist(features.ResourceAtlasProject, featureCustomRoles) && !br.Validator.IsResourceSupported(features.ResourceAtlasCustomRole) {
-		customRoles, ferr := buildCustomRoles(br.ProjectStore, br.ProjectID)
+		customRoles, ferr := projectBuildCustomRoles(br.ProjectStore, br.ProjectID)
 		if ferr != nil {
 			return nil, ferr
 		}
@@ -275,8 +275,7 @@ func BuildProjectNamedConnectionSecret(credsProvider store.CredentialsGetter, na
 	return secret
 }
 
-//nolint:revive
-func buildCustomRoles(crProvider store.DatabaseRoleLister, projectID string) ([]akov2.CustomRole, error) {
+func projectBuildCustomRoles(crProvider store.DatabaseRoleLister, projectID string) ([]akov2.CustomRole, error) {
 	dbRoles, err := crProvider.DatabaseRoles(projectID)
 	if err != nil {
 		return nil, err

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -1510,7 +1510,7 @@ func Test_buildCustomRoles(t *testing.T) {
 			},
 		}
 
-		got, err := buildCustomRoles(rolesProvider, projectID)
+		got, err := projectBuildCustomRoles(rolesProvider, projectID)
 		if err != nil {
 			t.Fatalf("%v", err)
 		}


### PR DESCRIPTION
## Proposed changes

Ports over any changes to relevant packages in AtlasCLI since the initial migration of code. This includes the fix to operator install tests.

[CLOUDP-279516](https://jira.mongodb.org/browse/CLOUDP-279516) been excluded as commands are not long-running watchers.

_Jira ticket:_ [CLOUDP-296183](https://jira.mongodb.org/browse/CLOUDP-296183)


## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments