### PR TITLE
ci: Setup signing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Atlas CLI Kubernetes Plugin
+
+The Atlas CLI Kubernetes Plugin is a first class plugin, providing kubernetes commands for the MongoDB Atlas CLI.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,5 +15,6 @@ git push origin "v1.0.0"
 
 This will do the following things:
 1. The [evergreen](build/ci/release.yml) release task will run after a tag event from main.
+2. This task signs all packages and includes both them and the public key in the release.
 2. If everything goes smoothly, the release will be published in the [releases page](https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases).
 3. The [evergreen](build/ci/release.yml) copybara task will automatically open a PR on docs repositories with any document changes for the docs team to review and merge. 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,5 +16,5 @@ git push origin "v1.0.0"
 This will do the following things:
 1. The [evergreen](build/ci/release.yml) release task will run after a tag event from main.
 2. This task signs all packages and includes both them and the public key in the release.
-2. If everything goes smoothly, the release will be published in the [releases page](https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases).
-3. The [evergreen](build/ci/release.yml) copybara task will automatically open a PR on docs repositories with any document changes for the docs team to review and merge. 
+3. If everything goes smoothly, the release will be published in the [releases page](https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases).
+4. The [evergreen](build/ci/release.yml) copybara task will automatically open a PR on docs repositories with any document changes for the docs team to review and merge. 

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -53,6 +53,18 @@ functions:
           set -Eeou pipefail
 
           curl -sfL ${goreleaser_pro_tar_gz} | tar zx
+  # "install macos notarization service":
+  #   - command: shell.exec
+  #     type: setup
+  #     params:
+  #       working_dir: src/github.com/mongodb/atlas-cli-plugin-kubernetes
+  #       include_expansions_in_env:
+  #         - notary_service_url
+  #       script: |
+  #         set -Eeou pipefail
+  #         curl "${notary_service_url}" --output macos-notary.zip
+  #         unzip -u macos-notary.zip
+  #         chmod 755 ./linux_amd64/macnotary
   "generate notices":
     - command: subprocess.exec
       type: test
@@ -69,10 +81,17 @@ functions:
         <<: *go_options
         env:
           <<: *go_env
+          ARTIFACTORY_USERNAME: ${artifactory_username}
+          ARTIFACTORY_PASSWORD: ${artifactory_password}
+          GRS_USERNAME: ${garasign_username}
+          GRS_PASSWORD: ${garasign_password}
           GITHUB_TOKEN: ${github_token}
         include_expansions_in_env:
           - go_base_path
           - workdir
+          - notary_service_key_id
+          - notary_service_secret
+          - notary_service_url
           - goreleaser_key
           - version
         binary: build/package/package.sh
@@ -120,6 +139,7 @@ tasks:
     commands:
       - func: "generate notices"
       - func: "install goreleaser"
+      # - func: "install macos notarization service"
       - func: "install gh-token"
       - func: "package"
   - name: copybara
@@ -149,7 +169,7 @@ tasks:
 buildvariants:
   - name: release
     display_name: "Release AtlasCLI Plugin Kubernetes (goreleaser)"
-    git_tag_only: true
+    # git_tag_only: true
     run_on:
       - rhel90-small
     expansions:

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -53,18 +53,6 @@ functions:
           set -Eeou pipefail
 
           curl -sfL ${goreleaser_pro_tar_gz} | tar zx
-  # "install macos notarization service":
-  #   - command: shell.exec
-  #     type: setup
-  #     params:
-  #       working_dir: src/github.com/mongodb/atlas-cli-plugin-kubernetes
-  #       include_expansions_in_env:
-  #         - notary_service_url
-  #       script: |
-  #         set -Eeou pipefail
-  #         curl "${notary_service_url}" --output macos-notary.zip
-  #         unzip -u macos-notary.zip
-  #         chmod 755 ./linux_amd64/macnotary
   "generate notices":
     - command: subprocess.exec
       type: test
@@ -139,7 +127,6 @@ tasks:
     commands:
       - func: "generate notices"
       - func: "install goreleaser"
-      # - func: "install macos notarization service"
       - func: "install gh-token"
       - func: "package"
   - name: copybara
@@ -169,7 +156,7 @@ tasks:
 buildvariants:
   - name: release
     display_name: "Release AtlasCLI Plugin Kubernetes (goreleaser)"
-    # git_tag_only: true
+    git_tag_only: true
     run_on:
       - rhel90-small
     expansions:

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -6,7 +6,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - curl https://pgp.mongodb.com/atlas-cli.asc -o atlas-cli.asc ## TODO download sig pub keykey
+    - curl https://pgp.mongodb.com/atlas-cli.asc -o atlas-cli.asc
 
 builds:
   - <<: &build_defaults
@@ -23,11 +23,6 @@ builds:
     id: macos
     goos: [darwin]
     goarch: [amd64,arm64]
-    # hooks:
-    #   # This will notarize Apple binaries and replace goreleaser bins with the notarized ones
-    #   post:
-    #     - cmd: ./build/package/mac_notarize.sh
-    #       output: true
   - <<: *build_defaults
     id: windows
     goos: [windows]
@@ -74,27 +69,13 @@ checksum:
 signs:
   - id: all_artifacts
     signature: "${artifact}.sig"
-    cmd: "./build/package/linux_notarize.sh"
+    cmd: "./build/package/notarize.sh"
     ids:
       - linux
       - macos
       - windows
     artifacts: all
     output: true
-  # - id: macos_artifacts
-  #   signature: "${artifact}.sig"
-  #   cmd: "./build/package/macos_notarize.sh" ## TODO actually sign package not binary
-  #   ids:
-  #     - macos
-  #   artifacts: all
-  #   output: true
-  # - id: windows_artifacts
-  #   signature: "${artifact}.sig"
-  #   cmd: "./build/package/windows_notarize.sh" ## TODO actually sign package not binary
-  #   ids:
-  #     - windows
-  #   artifacts: all
-  #   output: true
 release:
   prerelease: auto
   name_template: "Atlas CLI Plugin Kubernetes v{{.Version}}"

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -3,6 +3,11 @@ project_name: atlas-cli-plugin-kubernetes
 
 version: 2
 
+before:
+  hooks:
+    - go mod tidy
+    - curl https://pgp.mongodb.com/atlas-cli.asc -o atlas-cli.asc ## TODO download sig pub keykey
+
 builds:
   - <<: &build_defaults
       env:
@@ -18,6 +23,11 @@ builds:
     id: macos
     goos: [darwin]
     goarch: [amd64,arm64]
+    # hooks:
+    #   # This will notarize Apple binaries and replace goreleaser bins with the notarized ones
+    #   post:
+    #     - cmd: ./build/package/mac_notarize.sh
+    #       output: true
   - <<: *build_defaults
     id: windows
     goos: [windows]
@@ -35,7 +45,7 @@ gomod: # https://goreleaser.com/customization/verifiable_builds/
   mod: mod
 
 archives:
-- id: linux_archives
+- id: linux
   name_template: atlas-cli-plugin-kubernetes_{{ .Version }}_{{ .Os }}_{{- if eq .Arch "amd64" }}x86_64{{- else }}{{ .Arch }}{{ end }}
   builds: [linux]
   <<: &archive_defaults
@@ -61,6 +71,32 @@ archives:
   format: zip
 checksum:
   name_template: checksums.txt
+signs:
+  - id: all_artifacts
+    signature: "${artifact}.sig"
+    cmd: "./build/package/linux_notarize.sh"
+    ids:
+      - linux
+      - macos
+      - windows
+    artifacts: all
+    output: true
+  # - id: macos_artifacts
+  #   signature: "${artifact}.sig"
+  #   cmd: "./build/package/macos_notarize.sh" ## TODO actually sign package not binary
+  #   ids:
+  #     - macos
+  #   artifacts: all
+  #   output: true
+  # - id: windows_artifacts
+  #   signature: "${artifact}.sig"
+  #   cmd: "./build/package/windows_notarize.sh" ## TODO actually sign package not binary
+  #   ids:
+  #     - windows
+  #   artifacts: all
+  #   output: true
 release:
   prerelease: auto
   name_template: "Atlas CLI Plugin Kubernetes v{{.Version}}"
+  extra_files:
+    - glob: ./*.asc

--- a/build/package/linux_notarize.sh
+++ b/build/package/linux_notarize.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeou pipefail
+
+# linux_notarize generates the detached sign of the Linux binaries via garasign-gpg.
+# This depends on binaries being generated in a goreleaser manner and gon being set up.
+# goreleaser should already take care of calling this script as a part of a custom publisher.
+
+echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" >> "signing-envfile"
+echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> "signing-envfile"
+
+if [[ -f "${artifact:?}" ]]; then
+  echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+
+  echo "notarizing package ${artifact}"
+
+  podman run \
+    --env-file=signing-envfile \
+    --rm \
+    -v "$(pwd)":"$(pwd)" \
+    -w "$(pwd)" \
+    artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-gpg \
+    /bin/bash -c "gpgloader && gpg --yes -v --armor -o ${artifact}.sig --detach-sign ${artifact}"
+fi
+
+echo "Signing of ${artifact} completed."
+

--- a/build/package/notarize.sh
+++ b/build/package/notarize.sh
@@ -16,7 +16,7 @@
 
 set -Eeou pipefail
 
-# linux_notarize generates the detached sign of the Linux binaries via garasign-gpg.
+# notarize generates the detached sign of all packages via garasign-gpg.
 # This depends on binaries being generated in a goreleaser manner and gon being set up.
 # goreleaser should already take care of calling this script as a part of a custom publisher.
 

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -32,12 +32,3 @@ make generate-all-manifests
 
 # avoid race conditions on the notarization step by using `-p 1`
 ./bin/goreleaser release --config "build/package/.goreleaser.yml" --clean -p 1
-
-# # check that the notarization service signed the mac binaries
-# SIGNED_FILE_NAME=atlas-cli-plugin-kubernetes_macos_signed.zip
-# if [[ -f "dist/$SIGNED_FILE_NAME" ]]; then
-# 	echo "$SIGNED_FILE_NAME exists. The Mac notarization service has run."
-# else
-# 	echo "ERROR: $SIGNED_FILE_NAME does not exist. The Mac notarization service has not run."
-# 	exit 1 # ERROR
-# fi

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -17,6 +17,10 @@
 set -Eeou pipefail
 
 export GOROOT="${GOROOT:?}"
+
+export NOTARY_SERVICE_URL=${notary_service_url:?}
+export MACOS_NOTARY_KEY=${notary_service_key_id:?}
+export MACOS_NOTARY_SECRET=${notary_service_secret:?}
 export GORELEASER_KEY=${goreleaser_key:?}
 export VERSION_GIT=${version:?}
 VERSION=$(git tag --list 'v*' --sort=-taggerdate | head -1 | cut -d 'v' -f 2)
@@ -28,3 +32,12 @@ make generate-all-manifests
 
 # avoid race conditions on the notarization step by using `-p 1`
 ./bin/goreleaser release --config "build/package/.goreleaser.yml" --clean -p 1
+
+# # check that the notarization service signed the mac binaries
+# SIGNED_FILE_NAME=atlas-cli-plugin-kubernetes_macos_signed.zip
+# if [[ -f "dist/$SIGNED_FILE_NAME" ]]; then
+# 	echo "$SIGNED_FILE_NAME exists. The Mac notarization service has run."
+# else
+# 	echo "ERROR: $SIGNED_FILE_NAME does not exist. The Mac notarization service has not run."
+# 	exit 1 # ERROR
+# fi


### PR DESCRIPTION
## Proposed changes

Adds signing to all packages and includes sig public key in release.
SIgning for binaries will be done as a part of [CLOUDP-297212](https://jira.mongodb.org/browse/CLOUDP-297212).

_Test release:_ https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases/tag/v0.0.2
Verifying package signature for macos package:
![image](https://github.com/user-attachments/assets/03ae0be7-8e55-455d-84d0-da8f87704807)

Noting that the current key used for signatures is the atlas-cli key. This is to avoid blocking this work. A request will be made to create a new key exclusively for signing the K8s plugin and, once this key is available, necessary changes will be made to the signing process to use this new key.


_Jira ticket:_ [CLOUDP-294915](https://jira.mongodb.org/browse/CLOUDP-294915)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments