### PR TITLE
ci: Setup signing for binaries

### DIFF
--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -85,6 +85,7 @@ functions:
           ARTIFACTORY_PASSWORD: ${artifactory_password}
           GRS_USERNAME: ${garasign_username}
           GRS_PASSWORD: ${garasign_password}
+          AUTHENTICODE_KEY_NAME: ${authenticode_key_name}
           GITHUB_TOKEN: ${github_token}
         include_expansions_in_env:
           - go_base_path

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -57,7 +57,7 @@ functions:
     - command: shell.exec
       type: setup
       params:
-        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        working_dir: src/github.com/mongodb/atlas-cli-plugin-kubernetes
         include_expansions_in_env:
           - notary_service_url
         script: |

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -134,9 +134,9 @@ functions:
 tasks:
   - name: package_goreleaser
     tags: ["packaging"]
-    # depends_on:
-    #   - name: compile
-    #     variant: "code_health"
+    depends_on:
+      - name: compile
+        variant: "code_health"
     commands:
       - func: "generate notices"
       - func: "install goreleaser"
@@ -170,7 +170,7 @@ tasks:
 buildvariants:
   - name: release
     display_name: "Release AtlasCLI Plugin Kubernetes (goreleaser)"
-    # git_tag_only: true
+    git_tag_only: true
     run_on:
       - rhel90-small
     expansions:

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -53,6 +53,18 @@ functions:
           set -Eeou pipefail
 
           curl -sfL ${goreleaser_pro_tar_gz} | tar zx
+  "install macos notarization service":
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src/github.com/mongodb/mongodb-atlas-cli
+        include_expansions_in_env:
+          - notary_service_url
+        script: |
+          set -Eeou pipefail
+          curl "${notary_service_url}" --output macos-notary.zip
+          unzip -u macos-notary.zip
+          chmod 755 ./linux_amd64/macnotary
   "generate notices":
     - command: subprocess.exec
       type: test
@@ -121,12 +133,13 @@ functions:
 tasks:
   - name: package_goreleaser
     tags: ["packaging"]
-    depends_on:
-      - name: compile
-        variant: "code_health"
+    # depends_on:
+    #   - name: compile
+    #     variant: "code_health"
     commands:
       - func: "generate notices"
       - func: "install goreleaser"
+      - func: "install macos notarization service"
       - func: "install gh-token"
       - func: "package"
   - name: copybara
@@ -156,7 +169,7 @@ tasks:
 buildvariants:
   - name: release
     display_name: "Release AtlasCLI Plugin Kubernetes (goreleaser)"
-    git_tag_only: true
+    # git_tag_only: true
     run_on:
       - rhel90-small
     expansions:

--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -23,11 +23,21 @@ builds:
     id: macos
     goos: [darwin]
     goarch: [amd64,arm64]
+    hooks:
+      # This will notarize Apple binaries and replace goreleaser bins with the notarized ones
+      post:
+        - cmd: ./build/package/mac_notarize.sh
+          output: true
   - <<: *build_defaults
     id: windows
     goos: [windows]
     goarch: [amd64]
     goamd64: [v1]
+    hooks:
+      # This will notarize the Windows binary and replace goreleaser bin with the notarized one
+      post:
+        - cmd: ./build/package/windows_notarize.sh
+          output: true
 gomod: # https://goreleaser.com/customization/verifiable_builds/
   # Proxy a module from proxy.golang.org, making the builds verifiable.
   # This will only be effective if running against a tag. Snapshots will ignore

--- a/build/package/mac_notarize.sh
+++ b/build/package/mac_notarize.sh
@@ -26,7 +26,7 @@ if [[ -f "./dist/macos_darwin_amd64_v1/atlas-cli-plugin-kubernetes" && -f "./dis
 	./linux_amd64/macnotary \
 		-f ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip \
 		-m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
-		-b com.mongodb.atlas-cli-plugin-kubernetes \ 
+		-b com.mongodb.atlas-cli-plugin-kubernetes \
 		-o ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip
 
 	echo "replacing original files"

--- a/build/package/mac_notarize.sh
+++ b/build/package/mac_notarize.sh
@@ -20,9 +20,9 @@ set -Eeou pipefail
 # This depends on binaries being generated in a goreleaser manner and gon being set up.
 # goreleaser should already take care of calling this script as a hook.
 
-if [[ -f "./dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes" && -f "./dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes" && ! -f "./dist/atlas-cli-plugin-kubernetes_macos_signed.zip" ]]; then
+if [[ -f "./dist/macos_darwin_amd64_v1/atlas-cli-plugin-kubernetes" && -f "./dist/macos_darwin_arm64/atlas-cli-plugin-kubernetes" && ! -f "./dist/atlas-cli-plugin-kubernetes_macos_signed.zip" ]]; then
 	echo "notarizing macOs binaries"
-	zip -r ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip ./dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes ./dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes # The Notarization Service takes an archive as input
+	zip -r ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip ./dist/macos_darwin_amd64_v1/atlas-cli-plugin-kubernetes ./dist/macos_darwin_arm64/atlas-cli-plugin-kubernetes # The Notarization Service takes an archive as input
 	./linux_amd64/macnotary \
 		-f ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip \
 		-m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
@@ -30,6 +30,6 @@ if [[ -f "./dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes" && -f ".
 		-o ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip
 
 	echo "replacing original files"
-	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_amd64_v1/bin/
-	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_arm64/bin/
+	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_amd64_v1/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_amd64_v1/
+	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_arm64/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_arm64/
 fi

--- a/build/package/mac_notarize.sh
+++ b/build/package/mac_notarize.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeou pipefail
+
+# mac_notarize generated binaries with Apple and replace the original binary with the notarized one
+# This depends on binaries being generated in a goreleaser manner and gon being set up.
+# goreleaser should already take care of calling this script as a hook.
+
+if [[ -f "./dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes" && -f "./dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes" && ! -f "./dist/atlas-cli-plugin-kubernetes_macos_signed.zip" ]]; then
+	echo "notarizing macOs binaries"
+	zip -r ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip ./dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes ./dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes # The Notarization Service takes an archive as input
+	./linux_amd64/macnotary \
+		-f ./dist/atlas-cli-plugin-kubernetes_amd64_arm64_bin.zip \
+		-m notarizeAndSign -u https://dev.macos-notary.build.10gen.cc/api \
+		-b com.mongodb.atlas-cli-plugin-kubernetes \ 
+		-o ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip
+
+	echo "replacing original files"
+	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_amd64_v1/bin/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_amd64_v1/bin/
+	unzip -oj ./dist/atlas-cli-plugin-kubernetes_macos_signed.zip dist/macos_darwin_arm64/bin/atlas-cli-plugin-kubernetes -d ./dist/macos_darwin_arm64/bin/
+fi

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -32,3 +32,12 @@ make generate-all-manifests
 
 # avoid race conditions on the notarization step by using `-p 1`
 ./bin/goreleaser release --config "build/package/.goreleaser.yml" --clean -p 1
+
+# check that the notarization service signed the mac binaries
+SIGNED_FILE_NAME=mongodb-atlas-cli_macos_signed.zip
+if [[ -f "dist/$SIGNED_FILE_NAME" ]]; then
+	echo "$SIGNED_FILE_NAME exists. The Mac notarization service has run."
+else
+	echo "ERROR: $SIGNED_FILE_NAME does not exist. The Mac notarization service has not run."
+	exit 1 # ERROR
+fi

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -34,7 +34,7 @@ make generate-all-manifests
 ./bin/goreleaser release --config "build/package/.goreleaser.yml" --clean -p 1
 
 # check that the notarization service signed the mac binaries
-SIGNED_FILE_NAME=mongodb-atlas-cli_macos_signed.zip
+SIGNED_FILE_NAME=atlas-cli-plugin-kubernetes_macos_signed.zip
 if [[ -f "dist/$SIGNED_FILE_NAME" ]]; then
 	echo "$SIGNED_FILE_NAME exists. The Mac notarization service has run."
 else

--- a/build/package/windows_notarize.sh
+++ b/build/package/windows_notarize.sh
@@ -20,7 +20,7 @@ VERSION_GIT="$(git tag --list "v*" --sort=taggerdate | tail -1 | cut -d "v" -f 2
 
 EXE_FILE="./dist/windows_windows_amd64_v1/atlas-cli-plugin-kubernetes.exe"
 
-if [[ -f "$EXE_FILE"]]; then
+if [[ -f "$EXE_FILE" ]]; then
 	echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
 
 	echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" > .env

--- a/build/package/windows_notarize.sh
+++ b/build/package/windows_notarize.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 MongoDB Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -Eeou pipefail
+
+VERSION_GIT="$(git tag --list "v*" --sort=taggerdate | tail -1 | cut -d "v" -f 2)"
+
+EXE_FILE="./dist/windows_windows_amd64_v1/atlas-cli-plugin-kubernetes.exe"
+
+if [[ -f "$EXE_FILE"]]; then
+	echo "${ARTIFACTORY_PASSWORD}" | podman login --password-stdin --username "${ARTIFACTORY_USERNAME}" artifactory.corp.mongodb.com
+
+	echo "GRS_CONFIG_USER1_USERNAME=${GRS_USERNAME}" > .env
+	echo "GRS_CONFIG_USER1_PASSWORD=${GRS_PASSWORD}" >> .env
+
+	echo "signing $EXE_FILE"
+	podman run \
+		--env-file=.env \
+		--rm \
+		-v "$(pwd):$(pwd)" \
+		-w "$(pwd)" \
+		artifactory.corp.mongodb.com/release-tools-container-registry-local/garasign-jsign \
+		/bin/bash -c "jsign --tsaurl http://timestamp.digicert.com -a ${AUTHENTICODE_KEY_NAME} \"$EXE_FILE\""
+	
+	rm .env
+fi

--- a/build/package/windows_notarize.sh
+++ b/build/package/windows_notarize.sh
@@ -16,8 +16,6 @@
 
 set -Eeou pipefail
 
-VERSION_GIT="$(git tag --list "v*" --sort=taggerdate | tail -1 | cut -d "v" -f 2)"
-
 EXE_FILE="./dist/windows_windows_amd64_v1/atlas-cli-plugin-kubernetes.exe"
 
 if [[ -f "$EXE_FILE" ]]; then


### PR DESCRIPTION
## Proposed changes

Adds signing to MacOS and Windows binaries.

Testing was done on macOS binaries using `cosign`.
Testing was done on Win binary using guide provided [here](https://www.mongodb.com/docs/atlas/cli/current/verify-packages/#std-label-verify-packages) on Windows VM.

Test release: [v0.0.3](https://github.com/mongodb/atlas-cli-plugin-kubernetes/releases/tag/untagged-08cf420eab09ed0d805d)

_Jira ticket:_ [CLOUDP-297212](https://jira.mongodb.org/browse/CLOUDP-297212)

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments
