### PR TITLE
chore: Change signature public key name

### DIFF
--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -6,7 +6,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - curl https://pgp.mongodb.com/atlas-cli.asc -o atlas-cli.asc
+    - curl https://pgp.mongodb.com/atlas-cli.asc -o signature.asc
 
 builds:
   - <<: &build_defaults


### PR DESCRIPTION
## Proposed changes

Changes the name of public key to `signature.asc` as part of work for [CLOUDP-297009](https://jira.mongodb.org/browse/CLOUDP-297009). This unifies the pub key name to ensure that, if any bug arises that causes another pub key to be included in the release, AtlasCLI will collect the correct key.

_Note:_ Failure in E2E unrelated to changes in this PR.

_Jira ticket:_ CLOUDP-#

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments
