### PR TITLE
chore: Minor fix to manifest and make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ GOCOVERDIR?=$(abspath cov)
 
 PLUGIN_SOURCE_FILES?=./cmd/plugin
 ifeq ($(OS),Windows_NT)
-	PLUGIN_BINARY_NAME=atlas_cli_plugin_kubernetes.exe
+	PLUGIN_BINARY_NAME=atlas-cli-plugin-kubernetes.exe
 	E2E_ATLASCLI_BINARY_PATH=../bin/atlas.exe
 else
     ATLAS_VERSION?=$(shell git describe --match "atlascli/v*" | cut -d "v" -f 2)
-	PLUGIN_BINARY_NAME=atlas_cli_plugin_kubernetes
+	PLUGIN_BINARY_NAME=atlas-cli-plugin-kubernetes
 	E2E_ATLASCLI_BINARY_PATH=../bin/atlas
 endif
 PLUGIN_BINARY_PATH=./bin/$(PLUGIN_BINARY_NAME)

--- a/build/package/package.sh
+++ b/build/package/package.sh
@@ -25,8 +25,6 @@ export GORELEASER_KEY=${goreleaser_key:?}
 export VERSION_GIT=${version:?}
 VERSION=$(git tag --list 'v*' --sort=-taggerdate | head -1 | cut -d 'v' -f 2)
 export VERSION
-export GITHUB_REPOSITORY_OWNER="mongodb"
-export GITHUB_REPOSITORY_NAME="atlas-cli-plugin-kubernetes"
 
 make generate-all-manifests
 

--- a/manifest.template.yml
+++ b/manifest.template.yml
@@ -2,9 +2,9 @@ name: atlas-cli-plugin-kubernetes
 description: Root command of the Kubernetes plugin to manage Kubernetes resources.
 version: $VERSION
 github:
-    owner: $GITHUB_REPOSITORY_OWNER
-    name: $GITHUB_REPOSITORY_NAME
+    owner: mongodb
+    name: atlas-cli-plugin-kubernetes
 binary: atlas-cli-plugin-kubernetes
 commands: 
     kubernetes: 
-        description: This command provides access to Kubernetes features within Atlas.
+        description: Manage Kubernetes resources.


### PR DESCRIPTION
## Proposed changes

Changes make build binary name to match binary name in release.
Changes command description in manifest to ensure docs remain same.
Declared repo owner and repo name directly in manifest to clean up make and releaser.

EVG failures are not due to changes in this PR (likely issue due to shimming)

_Jira ticket:_ CLOUDP-#

## Checklist

- [ ] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code
