### PR TITLE
chore: Changes signing key

### DIFF
--- a/build/package/.goreleaser.yml
+++ b/build/package/.goreleaser.yml
@@ -6,7 +6,7 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - curl https://pgp.mongodb.com/atlas-cli.asc -o signature.asc
+    - curl https://pgp.mongodb.com/atlas-cli-plugin-kubernetes.asc -o signature.asc
 
 builds:
   - <<: &build_defaults


### PR DESCRIPTION
## Proposed changes

New garasign and artifactory creds have been created to decouple K8s plugin from atlasCLI. This PR points releaser to new public key created as a part of this work.

Credentials have been changed in Evergreen variables to match this new public key.

_Jira ticket:_ CLOUDP-#

## Checklist

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments
