### PR TITLE
chore: Adds debug flag

### DIFF
--- a/internal/flag/flags.go
+++ b/internal/flag/flags.go
@@ -18,6 +18,8 @@ const (
 	OrgID                                 = "orgId"                         // OrgID flag to use an Organization ID
 	ProjectID                             = "projectId"                     // ProjectID flag to use a project ID
 	ClusterName                           = "clusterName"                   // ClusterName flag
+	Debug                                 = "debug"                         // Debug flag to set debug log level
+	DebugShort                            = "D"                             // DebugShort flag to set debug log level
 	OperatorIncludeSecrets                = "includeSecrets"                // OperatorIncludeSecrets flag
 	OperatorTargetNamespace               = "targetNamespace"               // OperatorTargetNamespace flag
 	OperatorWatchNamespace                = "watchNamespace"                // OperatorTargetNamespace flag

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -18,6 +18,7 @@ const (
 	ProjectID                             = "Hexadecimal string that identifies the project to use. This option overrides the settings in the configuration file or environment variable."
 	OrgID                                 = "Organization ID to use. This option overrides the settings in the configuration file or environment variable."
 	ExporterClusterName                   = "One or more comma separated cluster names to import"
+	Debug                                 = "Debug log level."
 	OperatorIncludeSecrets                = "Flag that generates kubernetes secrets with data for projects, users, deployments entities."
 	OperatorTargetNamespace               = "Namespaces to use for generated kubernetes entities"
 	OperatorVersion                       = "Version of Atlas Kubernetes Operator to generate resources for."


### PR DESCRIPTION
## Proposed changes

plugins do not have access to global flags. This work adds debug flag to the K8s plugin. 

Behaviour is as in AtlasCLI for all three commands:

![image](https://github.com/user-attachments/assets/d1539a4b-ce5e-4baf-9bd7-a0daccf5d72c)


_Jira ticket:_ [CLOUDP-300551](https://jira.mongodb.org/browse/CLOUDP-300551)


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [ ] I have run `make fmt` and formatted my code

## Further comments
