### PR TITLE
CLOUDP-303050: Replace Github CRD by embedded provider

### DIFF
--- a/internal/cli/kubernetes/config/generate.go
+++ b/internal/cli/kubernetes/config/generate.go
@@ -77,7 +77,7 @@ func (opts *GenerateOpts) initStores(ctx context.Context) func() error {
 		}
 		opts.credsStore = profile
 
-		opts.crdsProvider = crds.NewGithubAtlasCRDProvider()
+		opts.crdsProvider = &crds.EmbeddedAtlasCRDProvider{}
 
 		return nil
 	}

--- a/internal/cli/kubernetes/operator/install.go
+++ b/internal/cli/kubernetes/operator/install.go
@@ -124,7 +124,7 @@ func (opts *InstallOpts) Run(ctx context.Context) error {
 		return err
 	}
 
-	featureValidator, err := features.NewAtlasCRDs(crds.NewGithubAtlasCRDProvider(), crdVersion)
+	featureValidator, err := features.NewAtlasCRDs(&crds.EmbeddedAtlasCRDProvider{}, crdVersion)
 	if err != nil {
 		return err
 	}

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
@@ -1,0 +1,235 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupcompliancepolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupCompliancePolicy
+    listKind: AtlasBackupCompliancePolicyList
+    plural: atlasbackupcompliancepolicies
+    shortNames:
+    - abcp
+    singular: atlasbackupcompliancepolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupCompliancePolicy defines the desired state of a compliance
+          policy in Atlas.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              authorizedEmail:
+                description: Email address of the user who authorized to update the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserFirstName:
+                description: First name of the user who authorized to updated the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserLastName:
+                description: Last name of the user who authorized to updated the Backup
+                  Compliance Policy settings.
+                type: string
+              copyProtectionEnabled:
+                description: Flag that indicates whether to prevent cluster users
+                  from deleting backups copied to other regions, even if those additional
+                  snapshot regions are removed.
+                type: boolean
+              encryptionAtRestEnabled:
+                description: Flag that indicates whether Encryption at Rest using
+                  Customer Key Management is required for all clusters with a Backup
+                  Compliance Policy.
+                type: boolean
+              onDemandPolicy:
+                description: Specifications for on-demand policy.
+                properties:
+                  retentionUnit:
+                    description: 'Scope of the backup policy item: days, weeks, or
+                      months'
+                    enum:
+                    - days
+                    - weeks
+                    - months
+                    type: string
+                  retentionValue:
+                    description: Value to associate with RetentionUnit
+                    type: integer
+                required:
+                - retentionUnit
+                - retentionValue
+                type: object
+              overwriteBackupPolicies:
+                description: Flag that indicates whether to overwrite non complying
+                  backup policies with the new data protection settings or not.
+                type: boolean
+              pointInTimeEnabled:
+                description: Flag that indicates whether the cluster uses Continuous
+                  Cloud Backups with a Backup Compliance Policy.
+                type: boolean
+              restoreWindowDays:
+                description: Number of previous days that you can restore back to
+                  with Continuous Cloud Backup with a Backup Compliance Policy. This
+                  parameter applies only to Continuous Cloud Backups with a Backup
+                  Compliance Policy.
+                type: integer
+              scheduledPolicyItems:
+                description: List that contains the specifications for one scheduled
+                  policy.
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - authorizedEmail
+            - authorizedUserFirstName
+            - authorizedUserLastName
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackuppolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupPolicy
+    listKind: AtlasBackupPolicyList
+    plural: atlasbackuppolicies
+    shortNames:
+    - abp
+    singular: atlasbackuppolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupPolicySpec defines the desired state of AtlasBackupPolicy
+            properties:
+              items:
+                description: A list of BackupPolicy items
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - items
+            type: object
+          status:
+            properties:
+              backupScheduleIDs:
+                description: DeploymentID of the deployment using the backup policy
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -1,0 +1,212 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupschedules.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupSchedule
+    listKind: AtlasBackupScheduleList
+    plural: atlasbackupschedules
+    shortNames:
+    - abs
+    singular: atlasbackupschedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupSchedule is the Schema for the atlasbackupschedules
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupScheduleSpec defines the desired state of AtlasBackupSchedule
+            properties:
+              autoExportEnabled:
+                default: false
+                description: Specify true to enable automatic export of cloud backup
+                  snapshots to the AWS bucket. You must also define the export policy
+                  using export. If omitted, defaults to false.
+                type: boolean
+              copySettings:
+                description: Copy backups to other regions for increased resiliency
+                  and faster restores.
+                items:
+                  properties:
+                    cloudProvider:
+                      default: AWS
+                      description: Identifies the cloud provider that stores the snapshot
+                        copy.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      type: string
+                    frequencies:
+                      description: List that describes which types of snapshots to
+                        copy.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    regionName:
+                      description: Target region to copy snapshots belonging to replicationSpecId
+                        to.
+                      type: string
+                    shouldCopyOplogs:
+                      description: Flag that indicates whether to copy the oplogs
+                        to the target region.
+                      type: boolean
+                  type: object
+                type: array
+              export:
+                description: Export policy for automatically exporting cloud backup
+                  snapshots to AWS bucket.
+                properties:
+                  exportBucketId:
+                    description: Unique Atlas identifier of the AWS bucket which was
+                      granted access to export backup snapshot
+                    type: string
+                  frequencyType:
+                    default: monthly
+                    enum:
+                    - monthly
+                    type: string
+                required:
+                - exportBucketId
+                - frequencyType
+                type: object
+              policy:
+                description: A reference (name & namespace) for backup policy in the
+                  desired updated backup policy.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              referenceHourOfDay:
+                description: UTC Hour of day between 0 and 23, inclusive, representing
+                  which hour of the day that Atlas takes snapshots for backup policy
+                  items
+                format: int64
+                maximum: 23
+                minimum: 0
+                type: integer
+              referenceMinuteOfHour:
+                description: UTC Minutes after ReferenceHourOfDay that Atlas takes
+                  snapshots for backup policy items. Must be between 0 and 59, inclusive.
+                format: int64
+                maximum: 59
+                minimum: 0
+                type: integer
+              restoreWindowDays:
+                default: 1
+                description: Number of days back in time you can restore to with Continuous
+                  Cloud Backup accuracy. Must be a positive, non-zero integer. Applies
+                  to continuous cloud backups only.
+                format: int64
+                type: integer
+              updateSnapshots:
+                description: Specify true to apply the retention changes in the updated
+                  backup policy to snapshots that Atlas took previously.
+                type: boolean
+              useOrgAndGroupNamesInExportPrefix:
+                description: Specify true to use organization and project names instead
+                  of organization and project UUIDs in the path for the metadata files
+                  that Atlas uploads to your S3 bucket after it finishes exporting
+                  the snapshots
+                type: boolean
+            required:
+            - policy
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deploymentID:
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -1,0 +1,300 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatabaseusers.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDatabaseUser
+    listKind: AtlasDatabaseUserList
+    plural: atlasdatabaseusers
+    shortNames:
+    - adu
+    singular: atlasdatabaseuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.username
+      name: Username
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDatabaseUser is the Schema for the Atlas Database User API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasDatabaseUserSpec defines the desired state of Database
+              User in Atlas
+            properties:
+              awsIamType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database
+                  user authenticates with the Amazon Web Services (AWS)
+                  Identity and Access Management (IAM) credentials associated with
+                  the user or the user's role
+                enum:
+                - NONE
+                - USER
+                - ROLE
+                type: string
+              connectionSecret:
+                description: LocalObjectReference is a reference to an object in the
+                  same namespace as the referent
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              databaseName:
+                default: admin
+                description: DatabaseName is a Database against which Atlas authenticates
+                  the user. Default value is 'admin'.
+                type: string
+              deleteAfterDate:
+                description: |-
+                  DeleteAfterDate is a timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the user.
+                  The specified date must be in the future and within one week.
+                type: string
+              externalProjectRef:
+                description: ExternalProjectRef holds the Atlas project ID the user
+                  belongs to
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              labels:
+                description: |-
+                  Labels is an array containing key-value pairs that tag and categorize the database user.
+                  Each key and value has a maximum length of 255 characters.
+                items:
+                  description: LabelSpec contains key-value pairs that tag and categorize
+                    the Cluster/DBUser
+                  properties:
+                    key:
+                      maxLength: 255
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              oidcAuthType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database Username
+                  with OIDC federated authentication.
+                  To create a federated authentication user, specify the value
+                  of IDP_GROUP for this field
+                enum:
+                - NONE
+                - IDP_GROUP
+                type: string
+              passwordSecretRef:
+                description: PasswordSecret is a reference to the Secret keeping the
+                  user password.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              projectRef:
+                description: Project is a reference to AtlasProject resource the user
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              roles:
+                description: |-
+                  Roles is an array of this user's roles and the databases / collections on which the roles apply. A role allows
+                  the user to perform particular actions on the specified database.
+                items:
+                  description: |-
+                    RoleSpec allows the user to perform particular actions on the specified database.
+                    A role on the admin database can include privileges that apply to the other databases as well.
+                  properties:
+                    collectionName:
+                      description: CollectionName is a collection for which the role
+                        applies.
+                      type: string
+                    databaseName:
+                      description: |-
+                        DatabaseName is a database on which the user has the specified role. A role on the admin database can include
+                        privileges that apply to the other databases.
+                      type: string
+                    roleName:
+                      description: RoleName is a name of the role. This value can
+                        either be a built-in role or a custom role.
+                      type: string
+                  required:
+                  - databaseName
+                  - roleName
+                  type: object
+                minItems: 1
+                type: array
+              scopes:
+                description: Scopes is an array of clusters and Atlas Data Lakes that
+                  this user has access to.
+                items:
+                  description: |-
+                    ScopeSpec if present a database user only have access to the indicated resource (Cluster or Atlas Data Lake)
+                    if none is given then it has access to all.
+                    It's highly recommended to restrict the access of the database users only to a limited set of resources.
+                  properties:
+                    name:
+                      description: Name is a name of the cluster or Atlas Data Lake
+                        that the user has access to.
+                      type: string
+                    type:
+                      description: Type is a type of resource that the user has access
+                        to.
+                      enum:
+                      - CLUSTER
+                      - DATA_LAKE
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              username:
+                description: |-
+                  Username is a username for authenticating to MongoDB
+                  Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:
+                  In case of AWS IAM: the value should be AWS ARN for the IAM User/Role;
+                  In case of OIDC: the value should be the Identity Provider ID;
+                  In case of Plain text auth: the value can be anything
+                maxLength: 1024
+                type: string
+              x509Type:
+                default: NONE
+                description: X509Type is X.509 method by which the database authenticates
+                  the provided username
+                enum:
+                - NONE
+                - MANAGED
+                - CUSTOMER
+                type: string
+            required:
+            - roles
+            - username
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDatabaseUserStatus defines the observed state of AtlasProject
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              name:
+                description: UserName is the current name of database user.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              passwordVersion:
+                description: PasswordVersion is the 'ResourceVersion' of the password
+                  Secret that the Atlas Operator is aware of
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdatafederations.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdatafederations.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatafederations.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDataFederation
+    listKind: AtlasDataFederationList
+    plural: atlasdatafederations
+    shortNames:
+    - adf
+    singular: atlasdatafederation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDataFederation is the Schema for the Atlas Data Federation
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              cloudProviderConfig:
+                properties:
+                  aws:
+                    properties:
+                      roleId:
+                        type: string
+                      testS3Bucket:
+                        type: string
+                    type: object
+                type: object
+              dataProcessRegion:
+                properties:
+                  cloudProvider:
+                    enum:
+                    - AWS
+                    type: string
+                  region:
+                    enum:
+                    - SYDNEY_AUS
+                    - MUMBAI_IND
+                    - FRANKFURT_DEU
+                    - DUBLIN_IRL
+                    - LONDON_GBR
+                    - VIRGINIA_USA
+                    - OREGON_USA
+                    - SAOPAULO_BRA
+                    - SINGAPORE_SGP
+                    type: string
+                type: object
+              name:
+                type: string
+              privateEndpoints:
+                items:
+                  properties:
+                    endpointId:
+                      type: string
+                    provider:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              projectRef:
+                description: Project is a reference to AtlasProject resource the deployment
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              storage:
+                properties:
+                  databases:
+                    items:
+                      properties:
+                        collections:
+                          items:
+                            properties:
+                              dataSources:
+                                items:
+                                  properties:
+                                    allowInsecure:
+                                      type: boolean
+                                    collection:
+                                      type: string
+                                    collectionRegex:
+                                      type: string
+                                    database:
+                                      type: string
+                                    databaseRegex:
+                                      type: string
+                                    defaultFormat:
+                                      enum:
+                                      - .avro
+                                      - .avro.bz2
+                                      - .avro.gz
+                                      - .bson
+                                      - .bson.bz2
+                                      - .bson.gz
+                                      - .bsonx
+                                      - .csv
+                                      - .csv.bz2
+                                      - .csv.gz
+                                      - .json
+                                      - .json.bz2
+                                      - .json.gz
+                                      - .orc
+                                      - .parquet
+                                      - .tsv
+                                      - .tsv.bz2
+                                      - .tsv.gz
+                                      type: string
+                                    path:
+                                      type: string
+                                    provenanceFieldName:
+                                      type: string
+                                    storeName:
+                                      type: string
+                                    urls:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        maxWildcardCollections:
+                          type: integer
+                        name:
+                          type: string
+                        views:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              pipeline:
+                                type: string
+                              source:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  stores:
+                    items:
+                      properties:
+                        additionalStorageClasses:
+                          items:
+                            type: string
+                          type: array
+                        bucket:
+                          type: string
+                        delimiter:
+                          type: string
+                        includeTags:
+                          type: boolean
+                        name:
+                          type: string
+                        prefix:
+                          type: string
+                        provider:
+                          type: string
+                        public:
+                          type: boolean
+                        region:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdeployments.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasdeployments.yaml
@@ -1,0 +1,1120 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdeployments.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDeployment
+    listKind: AtlasDeploymentList
+    plural: atlasdeployments
+    shortNames:
+    - ad
+    singular: atlasdeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.stateName
+      name: Atlas State
+      type: string
+    - jsonPath: .status.mongoDBVersion
+      name: MongoDB Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDeployment is the Schema for the atlasdeployments API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AtlasDeploymentSpec defines the desired state of AtlasDeployment
+              Only one of DeploymentSpec, AdvancedDeploymentSpec and ServerlessSpec should be defined
+            properties:
+              backupRef:
+                description: Backup schedule for the AtlasDeployment
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              connectionSecret:
+                description: LocalObjectReference is a reference to an object in the
+                  same namespace as the referent
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              deploymentSpec:
+                description: Configuration for the advanced (v1.5) deployment API
+                  https://www.mongodb.com/docs/atlas/reference/api/clusters/
+                properties:
+                  backupEnabled:
+                    description: |-
+                      Applicable only for M10+ deployments.
+                      Flag that indicates if the deployment uses Cloud Backups for backups.
+                    type: boolean
+                  biConnector:
+                    description: |-
+                      Configuration of BI Connector for Atlas on this deployment.
+                      The MongoDB Connector for Business Intelligence for Atlas (BI Connector) is only available for M10 and larger deployments.
+                    properties:
+                      enabled:
+                        description: Flag that indicates whether or not BI Connector
+                          for Atlas is enabled on the deployment.
+                        type: boolean
+                      readPreference:
+                        description: Source from which the BI Connector for Atlas
+                          reads data. Each BI Connector for Atlas read preference
+                          contains a distinct combination of readPreference and readPreferenceTags
+                          options.
+                        type: string
+                    type: object
+                  clusterType:
+                    description: |-
+                      Type of the deployment that you want to create.
+                      The parameter is required if replicationSpecs are set or if Global Deployments are deployed.
+                    enum:
+                    - REPLICASET
+                    - SHARDED
+                    - GEOSHARDED
+                    type: string
+                  customZoneMapping:
+                    items:
+                      properties:
+                        location:
+                          type: string
+                        zone:
+                          type: string
+                      required:
+                      - location
+                      - zone
+                      type: object
+                    type: array
+                  diskSizeGB:
+                    description: |-
+                      Capacity, in gigabytes, of the host's root volume.
+                      Increase this number to add capacity, up to a maximum possible value of 4096 (i.e., 4 TB).
+                      This value must be a positive integer.
+                      The parameter is required if replicationSpecs are configured.
+                    maximum: 4096
+                    minimum: 0
+                    type: integer
+                  encryptionAtRestProvider:
+                    description: Cloud service provider that offers Encryption at
+                      Rest.
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - NONE
+                    type: string
+                  labels:
+                    description: |-
+                      Collection of key-value pairs that tag and categorize the deployment.
+                      Each key and value has a maximum length of 255 characters.
+                    items:
+                      description: LabelSpec contains key-value pairs that tag and
+                        categorize the Cluster/DBUser
+                      properties:
+                        key:
+                          maxLength: 255
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  managedNamespaces:
+                    items:
+                      description: ManagedNamespace represents the information about
+                        managed namespace configuration.
+                      properties:
+                        collection:
+                          type: string
+                        customShardKey:
+                          type: string
+                        db:
+                          type: string
+                        isCustomShardKeyHashed:
+                          type: boolean
+                        isShardKeyUnique:
+                          type: boolean
+                        numInitialChunks:
+                          type: integer
+                        presplitHashedZones:
+                          type: boolean
+                      required:
+                      - collection
+                      - db
+                      type: object
+                    type: array
+                  mongoDBMajorVersion:
+                    description: Version of the deployment to deploy.
+                    type: string
+                  mongoDBVersion:
+                    type: string
+                  name:
+                    description: |-
+                      Name of the advanced deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  paused:
+                    description: Flag that indicates whether the deployment should
+                      be paused.
+                    type: boolean
+                  pitEnabled:
+                    description: Flag that indicates the deployment uses continuous
+                      cloud backups.
+                    type: boolean
+                  replicationSpecs:
+                    description: Configuration for deployment regions.
+                    items:
+                      properties:
+                        numShards:
+                          description: |-
+                            Positive integer that specifies the number of shards to deploy in each specified zone.
+                            If you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.
+                            Don't create a sharded cluster with a single shard for production environments.
+                            Single-shard sharded clusters don't provide the same benefits as multi-shard configurations
+                          type: integer
+                        regionConfigs:
+                          description: |-
+                            Hardware specifications for nodes set for a given region.
+                            Each regionConfigs object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region.
+                            Each regionConfigs object must have either an analyticsSpecs object, electableSpecs object, or readOnlySpecs object.
+                            Tenant clusters only require electableSpecs. Dedicated clusters can specify any of these specifications, but must have at least one electableSpecs object within a replicationSpec.
+                            Every hardware specification must use the same instanceSize.
+                          items:
+                            properties:
+                              analyticsSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              autoScaling:
+                                description: AdvancedAutoScalingSpec configures your
+                                  deployment to automatically scale its storage
+                                properties:
+                                  compute:
+                                    description: Collection of settings that configure
+                                      how a deployment might scale its deployment
+                                      tier and whether the deployment can scale down.
+                                    properties:
+                                      enabled:
+                                        description: Flag that indicates whether deployment
+                                          tier auto-scaling is enabled. The default
+                                          is false.
+                                        type: boolean
+                                      maxInstanceSize:
+                                        description: 'Maximum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M40). Atlas requires this parameter
+                                          if "autoScaling.compute.enabled" : true.'
+                                        type: string
+                                      minInstanceSize:
+                                        description: 'Minimum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M10). Atlas requires this parameter
+                                          if "autoScaling.compute.scaleDownEnabled"
+                                          : true.'
+                                        type: string
+                                      scaleDownEnabled:
+                                        description: 'Flag that indicates whether
+                                          the deployment tier may scale down. Atlas
+                                          requires this parameter if "autoScaling.compute.enabled"
+                                          : true.'
+                                        type: boolean
+                                    type: object
+                                  diskGB:
+                                    description: Flag that indicates whether disk
+                                      auto-scaling is enabled. The default is true.
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              backingProviderName:
+                                description: |-
+                                  Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                                  This setting only works when "providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                                  Otherwise it should be equal to "providerName" value
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                type: string
+                              electableSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              priority:
+                                description: |-
+                                  Precedence is given to this region when a primary election occurs.
+                                  If your regionConfigs has only readOnlySpecs, analyticsSpecs, or both, set this value to 0.
+                                  If you have multiple regionConfigs objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order.
+                                  The highest priority is 7
+                                type: integer
+                              providerName:
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                - TENANT
+                                - SERVERLESS
+                                type: string
+                              readOnlySpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              regionName:
+                                description: |-
+                                  Physical location of your MongoDB deployment.
+                                  The region you choose can affect network latency for clients accessing your databases.
+                                type: string
+                            type: object
+                          type: array
+                        zoneName:
+                          description: Human-readable label that identifies the zone
+                            in a Global Cluster.
+                          type: string
+                      type: object
+                    type: array
+                  rootCertType:
+                    type: string
+                  searchIndexes:
+                    description: A list of atlas search indexes configuration for
+                      the current deployment
+                    items:
+                      description: SearchIndex is the CRD to configure part of the
+                        Atlas Search Index
+                      properties:
+                        DBName:
+                          description: Human-readable label that identifies the database
+                            that contains the collection with one or more Atlas Search
+                            indexes
+                          type: string
+                        collectionName:
+                          description: Human-readable label that identifies the collection
+                            that contains one or more Atlas Search indexes
+                          type: string
+                        name:
+                          description: Human-readable label that identifies this index.
+                            Must be unique for a deployment
+                          type: string
+                        search:
+                          description: Atlas search index configuration
+                          properties:
+                            mappings:
+                              description: Index specifications for the collection's
+                                fields
+                              properties:
+                                dynamic:
+                                  description: Flag that indicates whether the index
+                                    uses dynamic or static mappings. Required if mapping.fields
+                                    is omitted.
+                                  type: boolean
+                                fields:
+                                  description: One or more field specifications for
+                                    the Atlas Search index. Required if mapping.dynamic
+                                    is omitted or set to false.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            searchConfigurationRef:
+                              description: A reference to the AtlasSearchIndexConfig
+                                custom resource
+                              properties:
+                                name:
+                                  description: Name is the name of the Kubernetes
+                                    Resource
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of the Kubernetes
+                                    Resource
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            synonyms:
+                              description: Rule sets that map words to their synonyms
+                                in this index
+                              items:
+                                description: Synonym represents "Synonym" type of
+                                  Atlas Search Index
+                                properties:
+                                  analyzer:
+                                    description: Specific pre-defined method chosen
+                                      to apply to the synonyms to be searched
+                                    enum:
+                                    - lucene.standard
+                                    - lucene.standard
+                                    - lucene.simple
+                                    - lucene.whitespace
+                                    - lucene.keyword
+                                    - lucene.arabic
+                                    - lucene.armenian
+                                    - lucene.basque
+                                    - lucene.bengali
+                                    - lucene.brazilian
+                                    - lucene.bulgarian
+                                    - lucene.catalan
+                                    - lucene.chinese
+                                    - lucene.cjk
+                                    - lucene.czech
+                                    - lucene.danish
+                                    - lucene.dutch
+                                    - lucene.english
+                                    - lucene.finnish
+                                    - lucene.french
+                                    - lucene.galician
+                                    - lucene.german
+                                    - lucene.greek
+                                    - lucene.hindi
+                                    - lucene.hungarian
+                                    - lucene.indonesian
+                                    - lucene.irish
+                                    - lucene.italian
+                                    - lucene.japanese
+                                    - lucene.korean
+                                    - lucene.kuromoji
+                                    - lucene.latvian
+                                    - lucene.lithuanian
+                                    - lucene.morfologik
+                                    - lucene.nori
+                                    - lucene.norwegian
+                                    - lucene.persian
+                                    - lucene.portuguese
+                                    - lucene.romanian
+                                    - lucene.russian
+                                    - lucene.smartcn
+                                    - lucene.sorani
+                                    - lucene.spanish
+                                    - lucene.swedish
+                                    - lucene.thai
+                                    - lucene.turkish
+                                    - lucene.ukrainian
+                                    type: string
+                                  name:
+                                    description: Human-readable label that identifies
+                                      the synonym definition. Each name must be unique
+                                      within the same index definition
+                                    type: string
+                                  source:
+                                    description: Data set that stores the mapping
+                                      one or more words map to one or more synonyms
+                                      of those words
+                                    properties:
+                                      collection:
+                                        description: Human-readable label that identifies
+                                          the MongoDB collection that stores words
+                                          and their applicable synonyms
+                                        type: string
+                                    required:
+                                    - collection
+                                    type: object
+                                required:
+                                - analyzer
+                                - name
+                                - source
+                                type: object
+                              type: array
+                          required:
+                          - mappings
+                          - searchConfigurationRef
+                          type: object
+                        type:
+                          description: Type of the index
+                          enum:
+                          - search
+                          - vectorSearch
+                          type: string
+                        vectorSearch:
+                          description: Atlas vector search index configuration
+                          properties:
+                            fields:
+                              description: Array of JSON objects. See examples https://dochub.mongodb.org/core/avs-vector-type
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - fields
+                          type: object
+                      required:
+                      - DBName
+                      - collectionName
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  searchNodes:
+                    description: Settings for Search Nodes for the cluster. Currently,
+                      at most one search node configuration may be defined.
+                    items:
+                      properties:
+                        instanceSize:
+                          description: Hardware specification for the Search Node
+                            instance sizes.
+                          enum:
+                          - S20_HIGHCPU_NVME
+                          - S30_HIGHCPU_NVME
+                          - S40_HIGHCPU_NVME
+                          - S50_HIGHCPU_NVME
+                          - S60_HIGHCPU_NVME
+                          - S70_HIGHCPU_NVME
+                          - S80_HIGHCPU_NVME
+                          - S30_LOWCPU_NVME
+                          - S40_LOWCPU_NVME
+                          - S50_LOWCPU_NVME
+                          - S60_LOWCPU_NVME
+                          - S80_LOWCPU_NVME
+                          - S90_LOWCPU_NVME
+                          - S100_LOWCPU_NVME
+                          - S110_LOWCPU_NVME
+                          type: string
+                        nodeCount:
+                          description: Number of Search Nodes in the cluster.
+                          maximum: 32
+                          minimum: 2
+                          type: integer
+                      type: object
+                    maxItems: 1
+                    type: array
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                  versionReleaseSystem:
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: ExternalProjectRef holds the Atlas project ID the user
+                  belongs to
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              processArgs:
+                description: ProcessArgs allows to modify Advanced Configuration Options
+                properties:
+                  defaultReadConcern:
+                    type: string
+                  defaultWriteConcern:
+                    type: string
+                  failIndexKeyTooLong:
+                    type: boolean
+                  javascriptEnabled:
+                    type: boolean
+                  minimumEnabledTlsProtocol:
+                    type: string
+                  noTableScan:
+                    type: boolean
+                  oplogMinRetentionHours:
+                    type: string
+                  oplogSizeMB:
+                    format: int64
+                    type: integer
+                  sampleRefreshIntervalBIConnector:
+                    format: int64
+                    type: integer
+                  sampleSizeBIConnector:
+                    format: int64
+                    type: integer
+                type: object
+              projectRef:
+                description: Project is a reference to AtlasProject resource the deployment
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              serverlessSpec:
+                description: Configuration for the serverless deployment API. https://www.mongodb.com/docs/atlas/reference/api/serverless-instances/
+                properties:
+                  backupOptions:
+                    description: Serverless Backup Options
+                    properties:
+                      serverlessContinuousBackupEnabled:
+                        default: true
+                        description: ServerlessContinuousBackupEnabled
+                        type: boolean
+                    type: object
+                  name:
+                    description: |-
+                      Name of the serverless deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  privateEndpoints:
+                    items:
+                      properties:
+                        cloudProviderEndpointID:
+                          description: CloudProviderEndpointID is the identifier of
+                            the cloud provider endpoint.
+                          type: string
+                        name:
+                          description: Name is the name of the Serverless PrivateLink
+                            Service. Should be unique.
+                          type: string
+                        privateEndpointIpAddress:
+                          description: PrivateEndpointIPAddress is the IPv4 address
+                            of the private endpoint in your Azure VNet that someone
+                            added to this private endpoint service.
+                          type: string
+                      type: object
+                    type: array
+                  providerSettings:
+                    description: Configuration for the provisioned hosts on which
+                      MongoDB runs. The available options are specific to the cloud
+                      service provider.
+                    properties:
+                      autoScaling:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Range of instance sizes to which your deployment
+                          can scale.
+                        properties:
+                          autoIndexingEnabled:
+                            description: |-
+                              Deprecated: This flag is not supported anymore.
+                              Flag that indicates whether autopilot mode for Performance Advisor is enabled.
+                              The default is false.
+                            type: boolean
+                          compute:
+                            description: Collection of settings that configure how
+                              a deployment might scale its deployment tier and whether
+                              the deployment can scale down.
+                            properties:
+                              enabled:
+                                description: Flag that indicates whether deployment
+                                  tier auto-scaling is enabled. The default is false.
+                                type: boolean
+                              maxInstanceSize:
+                                description: 'Maximum instance size to which your
+                                  deployment can automatically scale (such as M40).
+                                  Atlas requires this parameter if "autoScaling.compute.enabled"
+                                  : true.'
+                                type: string
+                              minInstanceSize:
+                                description: 'Minimum instance size to which your
+                                  deployment can automatically scale (such as M10).
+                                  Atlas requires this parameter if "autoScaling.compute.scaleDownEnabled"
+                                  : true.'
+                                type: string
+                              scaleDownEnabled:
+                                description: 'Flag that indicates whether the deployment
+                                  tier may scale down. Atlas requires this parameter
+                                  if "autoScaling.compute.enabled" : true.'
+                                type: boolean
+                            type: object
+                          diskGBEnabled:
+                            description: Flag that indicates whether disk auto-scaling
+                              is enabled. The default is true.
+                            type: boolean
+                        type: object
+                      backingProviderName:
+                        description: |-
+                          Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                          This setting only works when "providerSetting.providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        type: string
+                      diskIOPS:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        format: int64
+                        type: integer
+                      diskTypeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Type of disk if you selected Azure as your
+                          cloud service provider.
+                        type: string
+                      encryptEBSVolume:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Flag that indicates whether the Amazon
+                          EBS encryption feature encrypts the host's root volume for
+                          both data at rest within the volume and for data moving
+                          between the volume and the deployment.
+                        type: boolean
+                      instanceSizeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Atlas provides different deployment tiers,
+                          each with a default storage capacity and RAM size. The deployment
+                          you select is used for all the data-bearing hosts in your
+                          deployment tier.
+                        type: string
+                      providerName:
+                        description: Cloud service provider on which Atlas provisions
+                          the hosts.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        - TENANT
+                        - SERVERLESS
+                        type: string
+                      regionName:
+                        description: |-
+                          Physical location of your MongoDB deployment.
+                          The region you choose can affect network latency for clients accessing your databases.
+                        type: string
+                      volumeType:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        enum:
+                        - STANDARD
+                        - PROVISIONED
+                        type: string
+                    required:
+                    - providerName
+                    type: object
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                required:
+                - name
+                - providerSettings
+                type: object
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDeploymentStatus defines the observed state of AtlasDeployment.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectionStrings:
+                description: ConnectionStrings is a set of connection strings that
+                  your applications use to connect to this cluster.
+                properties:
+                  private:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                    type: string
+                  privateEndpoint:
+                    description: |-
+                      Private endpoint connection strings.
+                      Each object describes the connection strings you can use to connect to this cluster through a private endpoint.
+                      Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                    items:
+                      description: |-
+                        PrivateEndpoint connection strings. Each object describes the connection strings
+                        you can use to connect to this cluster through a private endpoint.
+                        Atlas returns this parameter only if you deployed a private endpoint to all regions
+                        to which you deployed this cluster's nodes.
+                      properties:
+                        connectionString:
+                          description: Private-endpoint-aware mongodb:// connection
+                            string for this private endpoint.
+                          type: string
+                        endpoints:
+                          description: Private endpoint through which you connect
+                            to Atlas when you use connectionStrings.privateEndpoint[n].connectionString
+                            or connectionStrings.privateEndpoint[n].srvConnectionString.
+                          items:
+                            description: Endpoint through which you connect to Atlas
+                            properties:
+                              endpointId:
+                                description: Unique identifier of the private endpoint.
+                                type: string
+                              ip:
+                                description: Private IP address of the private endpoint
+                                  network interface you created in your Azure VNet.
+                                type: string
+                              providerName:
+                                description: Cloud provider to which you deployed
+                                  the private endpoint. Atlas returns AWS or AZURE.
+                                type: string
+                              region:
+                                description: Region to which you deployed the private
+                                  endpoint.
+                                type: string
+                            type: object
+                          type: array
+                        srvConnectionString:
+                          description: Private-endpoint-aware mongodb+srv:// connection
+                            string for this private endpoint.
+                          type: string
+                        srvShardOptimizedConnectionString:
+                          type: string
+                        type:
+                          description: |-
+                            Type of MongoDB process that you connect to with the connection strings
+
+                            Atlas returns:
+
+                            • MONGOD for replica sets, or
+
+                            • MONGOS for sharded clusters
+                          type: string
+                      type: object
+                    type: array
+                  privateSrv:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb+srv:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                      Use this URI format if your driver supports it. If it doesn't, use connectionStrings.private.
+                    type: string
+                  standard:
+                    description: Public mongodb:// connection string for this cluster.
+                    type: string
+                  standardSrv:
+                    description: Public mongodb+srv:// connection string for this
+                      cluster.
+                    type: string
+                type: object
+              customZoneMapping:
+                properties:
+                  customZoneMapping:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  zoneMappingErrMessage:
+                    type: string
+                  zoneMappingState:
+                    type: string
+                type: object
+              managedNamespaces:
+                items:
+                  properties:
+                    collection:
+                      type: string
+                    customShardKey:
+                      type: string
+                    db:
+                      type: string
+                    errMessage:
+                      type: string
+                    isCustomShardKeyHashed:
+                      type: boolean
+                    isShardKeyUnique:
+                      type: boolean
+                    numInitialChunks:
+                      type: integer
+                    presplitHashedZones:
+                      type: boolean
+                    status:
+                      type: string
+                  required:
+                  - collection
+                  - db
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              mongoURIUpdated:
+                description: |-
+                  MongoURIUpdated is a timestamp in ISO 8601 date and time format in UTC when the connection string was last updated.
+                  The connection string changes if you update any of the other values.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              replicaSets:
+                items:
+                  properties:
+                    id:
+                      type: string
+                    zoneName:
+                      type: string
+                  required:
+                  - id
+                  type: object
+                type: array
+              searchIndexes:
+                description: SearchIndexes contains a list of search indexes statuses
+                  configured for a project
+                items:
+                  properties:
+                    ID:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - ID
+                  - message
+                  - name
+                  - status
+                  type: object
+                type: array
+              serverlessPrivateEndpoints:
+                items:
+                  properties:
+                    _id:
+                      description: ID is the identifier of the Serverless PrivateLink
+                        Service.
+                      type: string
+                    cloudProviderEndpointId:
+                      description: CloudProviderEndpointID is the identifier of the
+                        cloud provider endpoint.
+                      type: string
+                    endpointServiceName:
+                      description: EndpointServiceName is the name of the PrivateLink
+                        endpoint service in AWS. Returns null while the endpoint service
+                        is being created.
+                      type: string
+                    errorMessage:
+                      description: ErrorMessage is the error message if the Serverless
+                        PrivateLink Service failed to create or connect.
+                      type: string
+                    name:
+                      description: Name is the name of the Serverless PrivateLink
+                        Service. Should be unique.
+                      type: string
+                    privateEndpointIpAddress:
+                      description: PrivateEndpointIPAddress is the IPv4 address of
+                        the private endpoint in your Azure VNet that someone added
+                        to this private endpoint service.
+                      type: string
+                    privateLinkServiceResourceId:
+                      description: PrivateLinkServiceResourceID is the root-relative
+                        path that identifies the Azure Private Link Service that MongoDB
+                        Cloud manages. MongoDB Cloud returns null while it creates
+                        the endpoint service.
+                      type: string
+                    providerName:
+                      description: ProviderName is human-readable label that identifies
+                        the cloud provider. Values include AWS or AZURE.
+                      type: string
+                    status:
+                      description: Status of the AWS Serverless PrivateLink connection.
+                      type: string
+                  type: object
+                type: array
+              stateName:
+                description: |-
+                  StateName is the current state of the cluster.
+                  The possible states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasfederatedauths.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasfederatedauths.yaml
@@ -1,0 +1,194 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasfederatedauths.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasFederatedAuth
+    listKind: AtlasFederatedAuthList
+    plural: atlasfederatedauths
+    shortNames:
+    - afa
+    singular: atlasfederatedauth
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasFederatedAuth is the Schema for the Atlasfederatedauth API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              connectionSecretRef:
+                description: |-
+                  Connection secret with API credentials for configuring the federation.
+                  These credentials must have OrganizationOwner permissions.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              domainAllowList:
+                description: Approved domains that restrict users who can join the
+                  organization based on their email address.
+                items:
+                  type: string
+                type: array
+              domainRestrictionEnabled:
+                default: false
+                description: |-
+                  Prevent users in the federation from accessing organizations outside of the federation, and creating new organizations.
+                  This option applies to the entire federation.
+                  See more information at https://www.mongodb.com/docs/atlas/security/federation-advanced-options/#restrict-user-membership-to-the-federation
+                type: boolean
+              enabled:
+                default: false
+                type: boolean
+              postAuthRoleGrants:
+                description: Atlas roles that are granted to a user in this organization
+                  after authenticating.
+                items:
+                  type: string
+                type: array
+              roleMappings:
+                description: Map IDP groups to Atlas roles.
+                items:
+                  description: RoleMapping maps an external group from an identity
+                    provider to roles within Atlas.
+                  properties:
+                    externalGroupName:
+                      description: ExternalGroupName is the name of the IDP group
+                        to which this mapping applies.
+                      maxLength: 200
+                      minLength: 1
+                      type: string
+                    roleAssignments:
+                      description: RoleAssignments define the roles within projects
+                        that should be given to members of the group.
+                      items:
+                        properties:
+                          projectName:
+                            description: The Atlas project in the same org in which
+                              the role should be given.
+                            type: string
+                          role:
+                            description: The role in Atlas that should be given to
+                              group members.
+                            enum:
+                            - ORG_MEMBER
+                            - ORG_READ_ONLY
+                            - ORG_BILLING_ADMIN
+                            - ORG_GROUP_CREATOR
+                            - ORG_OWNER
+                            - ORG_BILLING_READ_ONLY
+                            - ORG_TEAM_MEMBERS_ADMIN
+                            - GROUP_AUTOMATION_ADMIN
+                            - GROUP_BACKUP_ADMIN
+                            - GROUP_MONITORING_ADMIN
+                            - GROUP_OWNER
+                            - GROUP_READ_ONLY
+                            - GROUP_USER_ADMIN
+                            - GROUP_BILLING_ADMIN
+                            - GROUP_DATA_ACCESS_ADMIN
+                            - GROUP_DATA_ACCESS_READ_ONLY
+                            - GROUP_DATA_ACCESS_READ_WRITE
+                            - GROUP_CHARTS_ADMIN
+                            - GROUP_CLUSTER_MANAGER
+                            - GROUP_SEARCH_INDEX_EDITOR
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ssoDebugEnabled:
+                default: false
+                type: boolean
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasprojects.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasprojects.yaml
@@ -1,0 +1,1558 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasprojects.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasProject
+    listKind: AtlasProjectList
+    plural: atlasprojects
+    shortNames:
+    - ap
+    singular: atlasproject
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.name
+      name: Atlas Name
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasProject is the Schema for the atlasprojects API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasProjectSpec defines the desired state of Project in
+              Atlas
+            properties:
+              alertConfigurationSyncEnabled:
+                description: |-
+                  AlertConfigurationSyncEnabled is a flag that enables/disables Alert Configurations sync for the current Project.
+                  If true - project alert configurations will be synced according to AlertConfigurations.
+                  If not - alert configurations will not be modified by the operator. They can be managed through API, cli, UI.
+                type: boolean
+              alertConfigurations:
+                description: AlertConfiguration is a list of Alert Configurations
+                  configured for the current Project.
+                items:
+                  properties:
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiTokenRef:
+                            description: Secret containing a Slack API token or Bot
+                              token. Populated for the SLACK notifications type. If
+                              the token later becomes invalid, Atlas sends an email
+                              to the project owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogAPIKeyRef:
+                            description: Secret containing a Datadog API Key. Found
+                              in the Datadog dashboard. Populated for the DATADOG
+                              notifications type.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow name in lower-case letters.
+                            type: string
+                          flowdockApiTokenRef:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKeyRef:
+                            description: OpsGenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKeyRef:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsSecretRef:
+                            description: Secret containing a VictorOps API key and
+                              Routing key. Populated for the VICTOR_OPS notifications
+                              type. If the key later becomes invalid, Atlas sends
+                              an email to the project owner and eventually removes
+                              the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      type: array
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              auditing:
+                description: Auditing represents MongoDB Maintenance Windows
+                properties:
+                  auditAuthorizationSuccess:
+                    description: 'Indicates whether the auditing system captures successful
+                      authentication attempts for audit filters using the "atype"
+                      : "authCheck" auditing event. For more information, see auditAuthorizationSuccess'
+                    type: boolean
+                  auditFilter:
+                    description: JSON-formatted audit filter used by the project
+                    type: string
+                  enabled:
+                    description: Denotes whether or not the project associated with
+                      the {GROUP-ID} has database auditing enabled.
+                    type: boolean
+                type: object
+              backupCompliancePolicyRef:
+                description: BackupCompliancePolicyRef is a reference to the backup
+                  compliance CR.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              cloudProviderAccessRoles:
+                description: |-
+                  CloudProviderAccessRoles is a list of Cloud Provider Access Roles configured for the current Project.
+                  Deprecated: This configuration was deprecated in favor of CloudProviderIntegrations
+                items:
+                  description: |-
+                    CloudProviderAccessRole define an integration to a cloud provider
+                    Deprecated: This type is deprecated in favor of CloudProviderIntegration
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations is a list of Cloud Provider
+                  Integration configured for the current Project.
+                items:
+                  description: CloudProviderIntegration define an integration to a
+                    cloud provider
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              connectionSecretRef:
+                description: |-
+                  ConnectionSecret is the name of the Kubernetes Secret which contains the information about the way to connect to
+                  Atlas (organization ID, API keys). The default Operator connection configuration will be used if not provided.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              customRoles:
+                description: The customRoles lets you create, and change custom roles
+                  in your cluster. Use custom roles to specify custom sets of actions
+                  that the Atlas built-in roles can't describe.
+                items:
+                  properties:
+                    actions:
+                      description: List of the individual privilege actions that the
+                        role grants.
+                      items:
+                        properties:
+                          name:
+                            description: Human-readable label that identifies the
+                              privilege action.
+                            type: string
+                          resources:
+                            description: List of resources on which you grant the
+                              action.
+                            items:
+                              properties:
+                                cluster:
+                                  description: Flag that indicates whether to grant
+                                    the action on the cluster resource. If true, MongoDB
+                                    Cloud ignores Database and Collection parameters.
+                                  type: boolean
+                                collection:
+                                  description: Human-readable label that identifies
+                                    the collection on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                                database:
+                                  description: Human-readable label that identifies
+                                    the database on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        - resources
+                        type: object
+                      type: array
+                    inheritedRoles:
+                      description: List of the built-in roles that this custom role
+                        inherits.
+                      items:
+                        properties:
+                          database:
+                            description: Human-readable label that identifies the
+                              database on which someone grants the action to one MongoDB
+                              user.
+                            type: string
+                          name:
+                            description: Human-readable label that identifies the
+                              role inherited.
+                            type: string
+                        required:
+                        - database
+                        - name
+                        type: object
+                      type: array
+                    name:
+                      description: Human-readable label that identifies the role.
+                        This name must be unique for this custom role in this project.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              encryptionAtRest:
+                description: EncryptionAtRest allows to set encryption for AWS, Azure
+                  and GCP providers
+                properties:
+                  awsKms:
+                    description: AwsKms specifies AWS KMS configuration details and
+                      whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      region:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the AccessKeyID,
+                          SecretAccessKey, CustomerMasterKeyID and RoleID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valid:
+                        type: boolean
+                    type: object
+                  azureKeyVault:
+                    description: AzureKeyVault specifies Azure Key Vault configuration
+                      details and whether Encryption at Rest is enabled for an Atlas
+                      project.
+                    properties:
+                      azureEnvironment:
+                        type: string
+                      clientID:
+                        type: string
+                      enabled:
+                        type: boolean
+                      resourceGroupName:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the SubscriptionID,
+                          KeyVaultName, KeyIdentifier, Secret fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tenantID:
+                        type: string
+                    type: object
+                  googleCloudKms:
+                    description: GoogleCloudKms specifies GCP KMS configuration details
+                      and whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      secretRef:
+                        description: A reference to as Secret containing the ServiceAccountKey,
+                          KeyVersionResourceID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                type: object
+              integrations:
+                description: Integrations is a list of MongoDB Atlas integrations
+                  for the project
+                items:
+                  properties:
+                    accountId:
+                      type: string
+                    apiKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    apiTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    channelName:
+                      type: string
+                    enabled:
+                      type: boolean
+                    flowName:
+                      type: string
+                    licenseKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    microsoftTeamsWebhookUrl:
+                      type: string
+                    name:
+                      type: string
+                    orgName:
+                      type: string
+                    passwordRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    readTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    region:
+                      type: string
+                    routingKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    scheme:
+                      type: string
+                    secretRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    serviceDiscovery:
+                      type: string
+                    serviceKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    teamName:
+                      type: string
+                    type:
+                      description: Third Party Integration type such as Slack, New
+                        Relic, etc
+                      enum:
+                      - PAGER_DUTY
+                      - SLACK
+                      - DATADOG
+                      - NEW_RELIC
+                      - OPS_GENIE
+                      - VICTOR_OPS
+                      - FLOWDOCK
+                      - WEBHOOK
+                      - MICROSOFT_TEAMS
+                      - PROMETHEUS
+                      type: string
+                    url:
+                      type: string
+                    username:
+                      type: string
+                    writeTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              maintenanceWindow:
+                description: |-
+                  MaintenanceWindow allows to specify a preferred time in the week to run maintenance operations. See more
+                  information at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+                properties:
+                  autoDefer:
+                    description: Flag indicating whether any scheduled project maintenance
+                      should be deferred automatically for one week.
+                    type: boolean
+                  dayOfWeek:
+                    description: |-
+                      Day of the week when you would like the maintenance window to start as a 1-based integer.
+                      Sunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    maximum: 7
+                    minimum: 1
+                    type: integer
+                  defer:
+                    description: |-
+                      Flag indicating whether the next scheduled project maintenance should be deferred for one week.
+                      Cannot be specified if startASAP is true
+                    type: boolean
+                  hourOfDay:
+                    description: |-
+                      Hour of the day when you would like the maintenance window to start.
+                      This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+                    maximum: 23
+                    minimum: 0
+                    type: integer
+                  startASAP:
+                    description: |-
+                      Flag indicating whether project maintenance has been directed to start immediately.
+                      Cannot be specified if defer is true
+                    type: boolean
+                type: object
+              name:
+                description: Name is the name of the Project that is created in Atlas
+                  by the Operator if it doesn't exist yet.
+                type: string
+              networkPeers:
+                description: NetworkPeers is a list of Network Peers configured for
+                  the current Project.
+                items:
+                  properties:
+                    accepterRegionName:
+                      description: AccepterRegionName is the provider region name
+                        of user's vpc.
+                      type: string
+                    atlasCidrBlock:
+                      description: Atlas CIDR. It needs to be set if ContainerID is
+                        not set.
+                      type: string
+                    awsAccountId:
+                      description: AccountID of the user's vpc.
+                      type: string
+                    azureDirectoryId:
+                      description: AzureDirectoryID is the unique identifier for an
+                        Azure AD directory.
+                      type: string
+                    azureSubscriptionId:
+                      description: AzureSubscriptionID is the unique identifier of
+                        the Azure subscription in which the VNet resides.
+                      type: string
+                    containerId:
+                      description: ID of the network peer container. If not set, operator
+                        will create a new container with ContainerRegion and AtlasCIDRBlock
+                        input.
+                      type: string
+                    containerRegion:
+                      description: ContainerRegion is the provider region name of
+                        Atlas network peer container. If not set, AccepterRegionName
+                        is used.
+                      type: string
+                    gcpProjectId:
+                      description: User GCP Project ID. Its applicable only for GCP.
+                      type: string
+                    networkName:
+                      description: GCP Network Peer Name. Its applicable only for
+                        GCP.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the provider. If not
+                        set, it will be set to "AWS".
+                      type: string
+                    resourceGroupName:
+                      description: ResourceGroupName is the name of your Azure resource
+                        group.
+                      type: string
+                    routeTableCidrBlock:
+                      description: User VPC CIDR.
+                      type: string
+                    vnetName:
+                      description: VNetName is name of your Azure VNet. Its applicable
+                        only for Azure.
+                      type: string
+                    vpcId:
+                      description: AWS VPC ID.
+                      type: string
+                  type: object
+                type: array
+              privateEndpoints:
+                description: PrivateEndpoints is a list of Private Endpoints configured
+                  for the current Project.
+                items:
+                  properties:
+                    endpointGroupName:
+                      description: Unique identifier of the endpoint group. The endpoint
+                        group encompasses all of the endpoints that you created in
+                        Google Cloud.
+                      type: string
+                    endpoints:
+                      description: Collection of individual private endpoints that
+                        comprise your endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            description: Forwarding rule that corresponds to the endpoint
+                              you created in Google Cloud.
+                            type: string
+                          ipAddress:
+                            description: Private IP address of the endpoint you created
+                              in Google Cloud.
+                            type: string
+                        type: object
+                      type: array
+                    gcpProjectId:
+                      description: Unique identifier of the Google Cloud project in
+                        which you created your endpoints.
+                      type: string
+                    id:
+                      description: Unique identifier of the private endpoint you created
+                        in your AWS VPC or Azure Vnet.
+                      type: string
+                    ip:
+                      description: Private IP address of the private endpoint network
+                        interface you created in your Azure VNet.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      - TENANT
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              projectIpAccessList:
+                description: |-
+                  ProjectIPAccessList allows to enable the IP Access List for the Project. See more information at
+                  https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              regionUsageRestrictions:
+                default: NONE
+                description: |-
+                  RegionUsageRestrictions designate the project's AWS region when using Atlas for Government.
+                  This parameter should not be used with commercial Atlas.
+                  In Atlas for Government, not setting this field (defaulting to NONE) means the project is restricted to COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                enum:
+                - NONE
+                - GOV_REGIONS_ONLY
+                - COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                type: string
+              settings:
+                description: Settings allow to set Project Settings for the project
+                properties:
+                  isCollectDatabaseSpecificsStatisticsEnabled:
+                    type: boolean
+                  isDataExplorerEnabled:
+                    type: boolean
+                  isExtendedStorageSizesEnabled:
+                    type: boolean
+                  isPerformanceAdvisorEnabled:
+                    type: boolean
+                  isRealtimePerformancePanelEnabled:
+                    type: boolean
+                  isSchemaAdvisorEnabled:
+                    type: boolean
+                type: object
+              teams:
+                description: Teams enable you to grant project access roles to multiple
+                  users.
+                items:
+                  properties:
+                    roles:
+                      description: Roles the users of the team has over the project
+                      items:
+                        enum:
+                        - GROUP_OWNER
+                        - GROUP_CLUSTER_MANAGER
+                        - GROUP_DATA_ACCESS_ADMIN
+                        - GROUP_DATA_ACCESS_READ_WRITE
+                        - GROUP_DATA_ACCESS_READ_ONLY
+                        - GROUP_READ_ONLY
+                        type: string
+                      minItems: 1
+                      type: array
+                    teamRef:
+                      description: Reference to the team which will assigned to the
+                        project
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - roles
+                  - teamRef
+                  type: object
+                type: array
+              withDefaultAlertsSettings:
+                default: true
+                description: Flag that indicates whether to create the new project
+                  with the default alert settings enabled. This parameter defaults
+                  to true
+                type: boolean
+              x509CertRef:
+                description: X509CertRef is the name of the Kubernetes Secret which
+                  contains PEM-encoded CA certificate
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - name
+            type: object
+          status:
+            description: AtlasProjectStatus defines the observed state of AtlasProject
+            properties:
+              alertConfigurations:
+                description: AlertConfigurations contains a list of alert configuration
+                  statuses
+                items:
+                  properties:
+                    acknowledgedUntil:
+                      description: The date through which the alert has been acknowledged.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgementComment:
+                      description: The comment left by the user who acknowledged the
+                        alert. Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgingUsername:
+                      description: The username of the user who acknowledged the alert.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    alertConfigId:
+                      description: ID of the alert configuration that triggered this
+                        alert.
+                      type: string
+                    clusterId:
+                      description: The ID of the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    clusterName:
+                      description: The name the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    created:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was created.
+                      type: string
+                    currentValue:
+                      description: CurrentValue represents current value of the metric
+                        that triggered the alert. Only present for alerts of type
+                        HOST_METRIC.
+                      properties:
+                        number:
+                          description: The value of the metric.
+                          type: string
+                        units:
+                          description: The units for the value. Depends on the type
+                            of metric.
+                          type: string
+                      type: object
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    errorMessage:
+                      description: ErrorMessage is massage if the alert configuration
+                        is in an incorrect state.
+                      type: string
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    groupId:
+                      description: Unique identifier of the project that owns this
+                        alert configuration.
+                      type: string
+                    hostId:
+                      description: ID of the host to which the metric pertains. Only
+                        present for alerts of type HOST, HOST_METRIC, and REPLICA_SET.
+                      type: string
+                    hostnameAndPort:
+                      description: The hostname and port of each host to which the
+                        alert applies. Only present for alerts of type HOST, HOST_METRIC,
+                        and REPLICA_SET.
+                      type: string
+                    id:
+                      description: Unique identifier.
+                      type: string
+                    lastNotified:
+                      description: When the last notification was sent for this alert.
+                        Only present if notifications have been sent.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricName:
+                      description: The name of the measurement whose value went outside
+                        the threshold. Only present if eventTypeName is set to OUTSIDE_METRIC_THRESHOLD.
+                      type: string
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiToken:
+                            description: Slack API token or Bot token. Populated for
+                              the SLACK notifications type. If the token later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the token.
+                            type: string
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogApiKey:
+                            description: Datadog API Key. Found in the Datadog dashboard.
+                              Populated for the DATADOG notifications type.
+                            type: string
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow namse in lower-case letters.
+                            type: string
+                          flowdockApiToken:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            type: string
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKey:
+                            description: Opsgenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            type: string
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKey:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsApiKey:
+                            description: VictorOps API key. Populated for the VICTOR_OPS
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the key.
+                            type: string
+                          victorOpsRoutingKey:
+                            description: VictorOps routing key. Populated for the
+                              VICTOR_OPS notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                        type: object
+                      type: array
+                    replicaSetName:
+                      description: Name of the replica set. Only present for alerts
+                        of type HOST, HOST_METRIC, BACKUP, and REPLICA_SET.
+                      type: string
+                    resolved:
+                      description: When the alert was closed. Only present if the
+                        status is CLOSED.
+                      type: string
+                    sourceTypeName:
+                      description: For alerts of the type BACKUP, the type of server
+                        being backed up.
+                      type: string
+                    status:
+                      description: 'The current state of the alert. Possible values
+                        are: TRACKING, OPEN, CLOSED, CANCELED'
+                      type: string
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                    updated:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was last updated.
+                      type: string
+                  type: object
+                type: array
+              authModes:
+                description: |-
+                  AuthModes contains a list of configured authentication modes
+                  "SCRAM" is default authentication method and requires a password for each user
+                  "X509" signifies that self-managed X.509 authentication is configured
+                items:
+                  type: string
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations contains a list of configured
+                  cloud provider access roles. AWS support only
+                items:
+                  properties:
+                    atlasAWSAccountArn:
+                      type: string
+                    atlasAssumedRoleExternalId:
+                      type: string
+                    authorizedDate:
+                      type: string
+                    createdDate:
+                      type: string
+                    errorMessage:
+                      type: string
+                    featureUsages:
+                      items:
+                        properties:
+                          featureId:
+                            type: string
+                          featureType:
+                            type: string
+                        type: object
+                      type: array
+                    iamAssumedRoleArn:
+                      type: string
+                    providerName:
+                      type: string
+                    roleId:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - atlasAssumedRoleExternalId
+                  - providerName
+                  type: object
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              customRoles:
+                description: CustomRoles contains a list of custom roles statuses
+                items:
+                  properties:
+                    error:
+                      description: The message when the custom role is in the FAILED
+                        status
+                      type: string
+                    name:
+                      description: Role name which is unique
+                      type: string
+                    status:
+                      description: The status of the given custom role (OK or FAILED)
+                      type: string
+                  required:
+                  - name
+                  - status
+                  type: object
+                type: array
+              expiredIpAccessList:
+                description: |-
+                  The list of IP Access List entries that are expired due to 'deleteAfterDate' being less than the current date.
+                  Note, that this field is updated by the Atlas Operator only after specification changes
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              id:
+                description: The ID of the Atlas Project
+                type: string
+              networkPeers:
+                description: The list of network peers that are configured for current
+                  project
+                items:
+                  properties:
+                    atlasGcpProjectId:
+                      description: ProjectID of Atlas container. Applicable only for
+                        GCP. It's needed to add network peer connection.
+                      type: string
+                    atlasNetworkName:
+                      description: Atlas Network Name. Applicable only for GCP. It's
+                        needed to add network peer connection.
+                      type: string
+                    connectionId:
+                      description: Unique identifier of the network peer connection.
+                        Applicable only for AWS.
+                      type: string
+                    containerId:
+                      description: ContainerID of Atlas network peer container.
+                      type: string
+                    errorMessage:
+                      description: Error state of the network peer. Applicable only
+                        for GCP.
+                      type: string
+                    errorState:
+                      description: Error state of the network peer. Applicable only
+                        for Azure.
+                      type: string
+                    errorStateName:
+                      description: Error state of the network peer. Applicable only
+                        for AWS.
+                      type: string
+                    gcpProjectId:
+                      description: ProjectID of the user's vpc. Applicable only for
+                        GCP.
+                      type: string
+                    id:
+                      description: Unique identifier for NetworkPeer.
+                      type: string
+                    providerName:
+                      description: Cloud provider for which you want to retrieve a
+                        network peer.
+                      type: string
+                    region:
+                      description: Region for which you want to create the network
+                        peer. It isn't needed for GCP
+                      type: string
+                    status:
+                      description: Status of the network peer. Applicable only for
+                        GCP and Azure.
+                      type: string
+                    statusName:
+                      description: Status of the network peer. Applicable only for
+                        AWS.
+                      type: string
+                    vpc:
+                      description: |-
+                        VPC is general purpose field for storing the name of the VPC.
+                        VPC is vpcID for AWS, user networkName for GCP, and vnetName for Azure.
+                      type: string
+                  required:
+                  - id
+                  - providerName
+                  - region
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              privateEndpoints:
+                description: The list of private endpoints configured for current
+                  project
+                items:
+                  properties:
+                    endpoints:
+                      description: Collection of individual GCP private endpoints
+                        that comprise your network endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            type: string
+                          ipAddress:
+                            type: string
+                          status:
+                            type: string
+                        required:
+                        - endpointName
+                        - ipAddress
+                        - status
+                        type: object
+                      type: array
+                    id:
+                      description: Unique identifier for AWS or AZURE Private Link
+                        Connection.
+                      type: string
+                    interfaceEndpointId:
+                      description: Unique identifier of the AWS or Azure Private Link
+                        Interface Endpoint.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                    serviceAttachmentNames:
+                      description: Unique alphanumeric and special character strings
+                        that identify the service attachments associated with the
+                        GCP Private Service Connect endpoint service.
+                      items:
+                        type: string
+                      type: array
+                    serviceName:
+                      description: Name of the AWS or Azure Private Link Service that
+                        Atlas manages.
+                      type: string
+                    serviceResourceId:
+                      description: Unique identifier of the Azure Private Link Service
+                        (for AWS the same as ID).
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              prometheus:
+                description: |-
+                  Prometheus contains the status for Prometheus integration
+                  including the prometheusDiscoveryURL
+                properties:
+                  prometheusDiscoveryURL:
+                    type: string
+                  scheme:
+                    type: string
+                type: object
+              teams:
+                description: Teams contains a list of teams assignment statuses
+                items:
+                  properties:
+                    id:
+                      type: string
+                    teamRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - teamRef
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
@@ -1,0 +1,287 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlassearchindexconfigs.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasSearchIndexConfig
+    listKind: AtlasSearchIndexConfigList
+    plural: atlassearchindexconfigs
+    shortNames:
+    - asic
+    singular: atlassearchindexconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analyzer:
+                description: |-
+                  Specific pre-defined method chosen to convert database field text into searchable words. This conversion reduces the text of fields into the smallest units of text. These units are called a term or token. This process, known as tokenization, involves a variety of changes made to the text in fields:
+                  - extracting words
+                  - removing punctuation
+                  - removing accents
+                  - hanging to lowercase
+                  - removing common words
+                  - reducing words to their root form (stemming)
+                  - changing words to their base form (lemmatization) MongoDB Cloud uses the selected process to build the Atlas Search index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              analyzers:
+                description: List of user-defined methods to convert database field
+                  text into searchable words
+                items:
+                  properties:
+                    charFilters:
+                      description: Filters that examine text one character at a time
+                        and perform filtering operations
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      description: |-
+                        Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings:
+                        "lucene.", "builtin.", "mongodb."
+                      type: string
+                    tokenFilters:
+                      description: |-
+                        Filter that performs operations such as:
+                        - Stemming, which reduces related words, such as "talking", "talked", and "talks" to their root word "talk".
+                        - Redaction, the removal of sensitive information from public documents
+                      x-kubernetes-preserve-unknown-fields: true
+                    tokenizer:
+                      description: Tokenizer that you want to use to create tokens.
+                        Tokens determine how Atlas Search splits up text into discrete
+                        chunks for indexing
+                      properties:
+                        group:
+                          description: Index of the character group within the matching
+                            expression to extract into tokens. Use `0` to extract
+                            all character groups.
+                          type: integer
+                        maxGram:
+                          description: Characters to include in the longest token
+                            that Atlas Search creates.
+                          type: integer
+                        maxTokenLength:
+                          description: Maximum number of characters in a single token.
+                            Tokens greater than this length are split at this length
+                            into multiple tokens.
+                          type: integer
+                        minGram:
+                          description: Characters to include in the shortest token
+                            that Atlas Search creates.
+                          type: integer
+                        pattern:
+                          description: Regular expression to match against.
+                          type: string
+                        type:
+                          description: Human-readable label that identifies this tokenizer
+                            type.
+                          enum:
+                          - whitespace
+                          - uaxUrlEmail
+                          - standard
+                          - regexSplit
+                          - regexCaptureGroup
+                          - nGram
+                          - keyword
+                          - edgeGram
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - tokenizer
+                  type: object
+                type: array
+              searchAnalyzer:
+                description: Method applied to identify words when searching this
+                  index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              storedSource:
+                description: |-
+                  Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search. Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation:
+                  https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasstreamconnections.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasstreamconnections.yaml
@@ -1,0 +1,242 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreamconnections.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamConnection
+    listKind: AtlasStreamConnectionList
+    plural: atlasstreamconnections
+    shortNames:
+    - asc
+    singular: atlasstreamconnection
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamConnection is the Schema for the atlasstreamconnections
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  name:
+                    description: Name of the cluster configured for this connection
+                    type: string
+                  role:
+                    description: The name of a Built in or Custom DB Role to connect
+                      to an Atlas Cluster
+                    properties:
+                      name:
+                        description: The name of the role to use. Can be a built in
+                          role or a custom role
+                        type: string
+                      type:
+                        description: Type of the DB role. Can be either BuiltIn or
+                          Custom
+                        enum:
+                        - BUILT_IN
+                        - CUSTOM
+                        type: string
+                    required:
+                    - name
+                    - type
+                    type: object
+                required:
+                - name
+                - role
+                type: object
+              kafkaConfig:
+                description: The configuration to be used to connect to a Kafka Cluster
+                properties:
+                  authentication:
+                    description: User credentials required to connect to a Kafka Cluster.
+                      Includes the authentication type, as well as the parameters
+                      for that authentication mode
+                    properties:
+                      credentials:
+                        description: Reference to the secret containing th Username
+                          and Password of the account to connect to the Kafka cluster.
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      mechanism:
+                        description: Style of authentication. Can be one of PLAIN,
+                          SCRAM-256, or SCRAM-512
+                        enum:
+                        - PLAIN
+                        - SCRAM-256
+                        - SCRAM-512
+                        type: string
+                    required:
+                    - credentials
+                    - mechanism
+                    type: object
+                  bootstrapServers:
+                    description: Comma separated list of server addresses
+                    type: string
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: A map of Kafka key-value pairs for optional configuration.
+                      This is a flat object, and keys can have '.' characters
+                    type: object
+                  security:
+                    description: Properties for the secure transport connection to
+                      Kafka. For SSL, this can include the trusted certificate to
+                      use
+                    properties:
+                      certificate:
+                        description: A trusted, public x509 certificate for connecting
+                          to Kafka over SSL
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      protocol:
+                        description: Describes the transport type. Can be either PLAINTEXT
+                          or SSL
+                        enum:
+                        - PLAINTEXT
+                        - SSL
+                        type: string
+                    required:
+                    - protocol
+                    type: object
+                required:
+                - authentication
+                - bootstrapServers
+                - security
+                type: object
+              name:
+                description: Human-readable label that uniquely identifies the stream
+                  connection
+                type: string
+              type:
+                description: Type of the connection. Can be either Cluster or Kafka
+                enum:
+                - Kafka
+                - Cluster
+                - Sample
+                type: string
+            required:
+            - name
+            - type
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: List of instances using the connection configuration
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasstreaminstances.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasstreaminstances.yaml
@@ -1,0 +1,213 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreaminstances.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamInstance
+    listKind: AtlasStreamInstanceList
+    plural: atlasstreaminstances
+    shortNames:
+    - asi
+    singular: atlasstreaminstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamInstance is the Schema for the atlasstreaminstances
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  provider:
+                    default: AWS
+                    description: Name of the cluster configured for this connection
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - TENANT
+                    - SERVERLESS
+                    type: string
+                  region:
+                    description: Name of the cloud provider region hosting Atlas Stream
+                      Processing.
+                    type: string
+                  tier:
+                    default: SP10
+                    description: Selected tier for the Stream Instance. Configures
+                      Memory / VCPU allowances.
+                    enum:
+                    - SP10
+                    - SP30
+                    - SP50
+                    type: string
+                required:
+                - provider
+                - region
+                - tier
+                type: object
+              connectionRegistry:
+                description: List of connections of the stream instance for the specified
+                  project
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Human-readable label that identifies the stream connection
+                type: string
+              projectRef:
+                description: Project which the instance belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - clusterConfig
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connections:
+                description: List of connections configured in the stream instance.
+                items:
+                  properties:
+                    name:
+                      description: Human-readable label that uniquely identifies the
+                        stream connection
+                      type: string
+                    resourceRef:
+                      description: Reference for the resource that contains connection
+                        configuration
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              hostnames:
+                description: List that contains the hostnames assigned to the stream
+                  instance.
+                items:
+                  type: string
+                type: array
+              id:
+                description: Unique 24-hexadecimal character string that identifies
+                  the instance
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasteams.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.5.0/atlas.mongodb.com_atlasteams.yaml
@@ -1,0 +1,144 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasteams.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasTeam
+    listKind: AtlasTeamList
+    plural: atlasteams
+    shortNames:
+    - at
+    singular: atlasteam
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasTeam is the Schema for the Atlas Teams API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TeamSpec defines the desired state of a Team in Atlas
+            properties:
+              name:
+                description: The name of the team you want to create.
+                type: string
+              usernames:
+                description: Valid email addresses of users to add to the new team
+                items:
+                  format: email
+                  type: string
+                type: array
+            required:
+            - name
+            - usernames
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                description: ID of the team
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              projects:
+                description: List of projects which the team is assigned
+                items:
+                  properties:
+                    id:
+                      description: Unique identifier of the project inside atlas
+                      type: string
+                    name:
+                      description: Name given to the project
+                      type: string
+                  required:
+                  - id
+                  - name
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
@@ -1,0 +1,235 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupcompliancepolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupCompliancePolicy
+    listKind: AtlasBackupCompliancePolicyList
+    plural: atlasbackupcompliancepolicies
+    shortNames:
+    - abcp
+    singular: atlasbackupcompliancepolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupCompliancePolicy defines the desired state of a compliance
+          policy in Atlas.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              authorizedEmail:
+                description: Email address of the user who authorized to update the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserFirstName:
+                description: First name of the user who authorized to updated the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserLastName:
+                description: Last name of the user who authorized to updated the Backup
+                  Compliance Policy settings.
+                type: string
+              copyProtectionEnabled:
+                description: Flag that indicates whether to prevent cluster users
+                  from deleting backups copied to other regions, even if those additional
+                  snapshot regions are removed.
+                type: boolean
+              encryptionAtRestEnabled:
+                description: Flag that indicates whether Encryption at Rest using
+                  Customer Key Management is required for all clusters with a Backup
+                  Compliance Policy.
+                type: boolean
+              onDemandPolicy:
+                description: Specifications for on-demand policy.
+                properties:
+                  retentionUnit:
+                    description: 'Scope of the backup policy item: days, weeks, or
+                      months'
+                    enum:
+                    - days
+                    - weeks
+                    - months
+                    type: string
+                  retentionValue:
+                    description: Value to associate with RetentionUnit
+                    type: integer
+                required:
+                - retentionUnit
+                - retentionValue
+                type: object
+              overwriteBackupPolicies:
+                description: Flag that indicates whether to overwrite non complying
+                  backup policies with the new data protection settings or not.
+                type: boolean
+              pointInTimeEnabled:
+                description: Flag that indicates whether the cluster uses Continuous
+                  Cloud Backups with a Backup Compliance Policy.
+                type: boolean
+              restoreWindowDays:
+                description: Number of previous days that you can restore back to
+                  with Continuous Cloud Backup with a Backup Compliance Policy. This
+                  parameter applies only to Continuous Cloud Backups with a Backup
+                  Compliance Policy.
+                type: integer
+              scheduledPolicyItems:
+                description: List that contains the specifications for one scheduled
+                  policy.
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - authorizedEmail
+            - authorizedUserFirstName
+            - authorizedUserLastName
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackuppolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupPolicy
+    listKind: AtlasBackupPolicyList
+    plural: atlasbackuppolicies
+    shortNames:
+    - abp
+    singular: atlasbackuppolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupPolicySpec defines the desired state of AtlasBackupPolicy
+            properties:
+              items:
+                description: A list of BackupPolicy items
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - items
+            type: object
+          status:
+            properties:
+              backupScheduleIDs:
+                description: DeploymentID of the deployment using the backup policy
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -1,0 +1,212 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupschedules.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupSchedule
+    listKind: AtlasBackupScheduleList
+    plural: atlasbackupschedules
+    shortNames:
+    - abs
+    singular: atlasbackupschedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupSchedule is the Schema for the atlasbackupschedules
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupScheduleSpec defines the desired state of AtlasBackupSchedule
+            properties:
+              autoExportEnabled:
+                default: false
+                description: Specify true to enable automatic export of cloud backup
+                  snapshots to the AWS bucket. You must also define the export policy
+                  using export. If omitted, defaults to false.
+                type: boolean
+              copySettings:
+                description: Copy backups to other regions for increased resiliency
+                  and faster restores.
+                items:
+                  properties:
+                    cloudProvider:
+                      default: AWS
+                      description: Identifies the cloud provider that stores the snapshot
+                        copy.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      type: string
+                    frequencies:
+                      description: List that describes which types of snapshots to
+                        copy.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    regionName:
+                      description: Target region to copy snapshots belonging to replicationSpecId
+                        to.
+                      type: string
+                    shouldCopyOplogs:
+                      description: Flag that indicates whether to copy the oplogs
+                        to the target region.
+                      type: boolean
+                  type: object
+                type: array
+              export:
+                description: Export policy for automatically exporting cloud backup
+                  snapshots to AWS bucket.
+                properties:
+                  exportBucketId:
+                    description: Unique Atlas identifier of the AWS bucket which was
+                      granted access to export backup snapshot
+                    type: string
+                  frequencyType:
+                    default: monthly
+                    enum:
+                    - monthly
+                    type: string
+                required:
+                - exportBucketId
+                - frequencyType
+                type: object
+              policy:
+                description: A reference (name & namespace) for backup policy in the
+                  desired updated backup policy.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              referenceHourOfDay:
+                description: UTC Hour of day between 0 and 23, inclusive, representing
+                  which hour of the day that Atlas takes snapshots for backup policy
+                  items
+                format: int64
+                maximum: 23
+                minimum: 0
+                type: integer
+              referenceMinuteOfHour:
+                description: UTC Minutes after ReferenceHourOfDay that Atlas takes
+                  snapshots for backup policy items. Must be between 0 and 59, inclusive.
+                format: int64
+                maximum: 59
+                minimum: 0
+                type: integer
+              restoreWindowDays:
+                default: 1
+                description: Number of days back in time you can restore to with Continuous
+                  Cloud Backup accuracy. Must be a positive, non-zero integer. Applies
+                  to continuous cloud backups only.
+                format: int64
+                type: integer
+              updateSnapshots:
+                description: Specify true to apply the retention changes in the updated
+                  backup policy to snapshots that Atlas took previously.
+                type: boolean
+              useOrgAndGroupNamesInExportPrefix:
+                description: Specify true to use organization and project names instead
+                  of organization and project UUIDs in the path for the metadata files
+                  that Atlas uploads to your S3 bucket after it finishes exporting
+                  the snapshots
+                type: boolean
+            required:
+            - policy
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deploymentID:
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlascustomroles.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlascustomroles.yaml
@@ -1,0 +1,224 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlascustomroles.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasCustomRole
+    listKind: AtlasCustomRoleList
+    plural: atlascustomroles
+    shortNames:
+    - acr
+    singular: atlascustomrole
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.role.name
+      name: Name
+      type: string
+    - jsonPath: .spec.projectIDRef.id
+      name: Project ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasCustomRole is the Schema for the AtlasCustomRole API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasCustomRoleSpec defines the desired state of CustomRole
+              in Atlas
+            properties:
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: Optional ID of the Atlas Project this role is attached
+                  to. Mutually exclusive with "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              projectRef:
+                description: Optional reference to an AtlasProject custom resource.
+                  Mutually exclusive with "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              role:
+                properties:
+                  actions:
+                    description: List of the individual privilege actions that the
+                      role grants.
+                    items:
+                      properties:
+                        name:
+                          description: Human-readable label that identifies the privilege
+                            action.
+                          type: string
+                        resources:
+                          description: List of resources on which you grant the action.
+                          items:
+                            properties:
+                              cluster:
+                                description: Flag that indicates whether to grant
+                                  the action on the cluster resource. If true, MongoDB
+                                  Cloud ignores Database and Collection parameters.
+                                type: boolean
+                              collection:
+                                description: Human-readable label that identifies
+                                  the collection on which you grant the action to
+                                  one MongoDB user.
+                                type: string
+                              database:
+                                description: Human-readable label that identifies
+                                  the database on which you grant the action to one
+                                  MongoDB user.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      - resources
+                      type: object
+                    type: array
+                  inheritedRoles:
+                    description: List of the built-in roles that this custom role
+                      inherits.
+                    items:
+                      properties:
+                        database:
+                          description: Human-readable label that identifies the database
+                            on which someone grants the action to one MongoDB user.
+                          type: string
+                        name:
+                          description: Human-readable label that identifies the role
+                            inherited.
+                          type: string
+                      required:
+                      - database
+                      - name
+                      type: object
+                    type: array
+                  name:
+                    description: Human-readable label that identifies the role. This
+                      name must be unique for this custom role in this project.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - role
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: |-
+              AtlasCustomRoleStatus is a status for the AtlasCustomRole Custom resource.
+              Not the one included in the AtlasProject
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -1,0 +1,303 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatabaseusers.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDatabaseUser
+    listKind: AtlasDatabaseUserList
+    plural: atlasdatabaseusers
+    shortNames:
+    - adu
+    singular: atlasdatabaseuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.username
+      name: Username
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDatabaseUser is the Schema for the Atlas Database User API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasDatabaseUserSpec defines the desired state of Database
+              User in Atlas
+            properties:
+              awsIamType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database
+                  user authenticates with the Amazon Web Services (AWS)
+                  Identity and Access Management (IAM) credentials associated with
+                  the user or the user's role
+                enum:
+                - NONE
+                - USER
+                - ROLE
+                type: string
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              databaseName:
+                default: admin
+                description: |-
+                  DatabaseName is a Database against which Atlas authenticates the user.
+                  If the user authenticates with AWS IAM, x.509, LDAP, or OIDC Workload this value should be '$external'.
+                  If the user authenticates with SCRAM-SHA or OIDC Workforce, this value should be 'admin'.
+                  Default value is 'admin'.
+                type: string
+              deleteAfterDate:
+                description: |-
+                  DeleteAfterDate is a timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the user.
+                  The specified date must be in the future and within one week.
+                type: string
+              externalProjectRef:
+                description: ExternalProjectRef holds the Atlas project ID the user
+                  belongs to
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              labels:
+                description: |-
+                  Labels is an array containing key-value pairs that tag and categorize the database user.
+                  Each key and value has a maximum length of 255 characters.
+                items:
+                  description: LabelSpec contains key-value pairs that tag and categorize
+                    the Cluster/DBUser
+                  properties:
+                    key:
+                      maxLength: 255
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              oidcAuthType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database Username with OIDC federated authentication.
+                  To create a federated authentication group (Workforce), specify the value of IDP_GROUP in this field.
+                  To create a federated authentication user (Workload), specify the value of USER in this field.
+                enum:
+                - NONE
+                - IDP_GROUP
+                - USER
+                type: string
+              passwordSecretRef:
+                description: PasswordSecret is a reference to the Secret keeping the
+                  user password.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              projectRef:
+                description: Project is a reference to AtlasProject resource the user
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              roles:
+                description: |-
+                  Roles is an array of this user's roles and the databases / collections on which the roles apply. A role allows
+                  the user to perform particular actions on the specified database.
+                items:
+                  description: |-
+                    RoleSpec allows the user to perform particular actions on the specified database.
+                    A role on the admin database can include privileges that apply to the other databases as well.
+                  properties:
+                    collectionName:
+                      description: CollectionName is a collection for which the role
+                        applies.
+                      type: string
+                    databaseName:
+                      description: |-
+                        DatabaseName is a database on which the user has the specified role. A role on the admin database can include
+                        privileges that apply to the other databases.
+                      type: string
+                    roleName:
+                      description: RoleName is a name of the role. This value can
+                        either be a built-in role or a custom role.
+                      type: string
+                  required:
+                  - databaseName
+                  - roleName
+                  type: object
+                minItems: 1
+                type: array
+              scopes:
+                description: Scopes is an array of clusters and Atlas Data Lakes that
+                  this user has access to.
+                items:
+                  description: |-
+                    ScopeSpec if present a database user only have access to the indicated resource (Cluster or Atlas Data Lake)
+                    if none is given then it has access to all.
+                    It's highly recommended to restrict the access of the database users only to a limited set of resources.
+                  properties:
+                    name:
+                      description: Name is a name of the cluster or Atlas Data Lake
+                        that the user has access to.
+                      type: string
+                    type:
+                      description: Type is a type of resource that the user has access
+                        to.
+                      enum:
+                      - CLUSTER
+                      - DATA_LAKE
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              username:
+                description: |-
+                  Username is a username for authenticating to MongoDB
+                  Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:
+                  In case of AWS IAM: the value should be AWS ARN for the IAM User/Role;
+                  In case of OIDC Workload or Workforce: the value should be the Atlas OIDC IdP ID, followed by a '/', followed by the IdP group name;
+                  In case of Plain text auth: the value can be anything
+                maxLength: 1024
+                type: string
+              x509Type:
+                default: NONE
+                description: X509Type is X.509 method by which the database authenticates
+                  the provided username
+                enum:
+                - NONE
+                - MANAGED
+                - CUSTOMER
+                type: string
+            required:
+            - roles
+            - username
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDatabaseUserStatus defines the observed state of AtlasProject
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              name:
+                description: UserName is the current name of database user.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              passwordVersion:
+                description: PasswordVersion is the 'ResourceVersion' of the password
+                  Secret that the Atlas Operator is aware of
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdatafederations.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdatafederations.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatafederations.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDataFederation
+    listKind: AtlasDataFederationList
+    plural: atlasdatafederations
+    shortNames:
+    - adf
+    singular: atlasdatafederation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDataFederation is the Schema for the Atlas Data Federation
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              cloudProviderConfig:
+                properties:
+                  aws:
+                    properties:
+                      roleId:
+                        type: string
+                      testS3Bucket:
+                        type: string
+                    type: object
+                type: object
+              dataProcessRegion:
+                properties:
+                  cloudProvider:
+                    enum:
+                    - AWS
+                    type: string
+                  region:
+                    enum:
+                    - SYDNEY_AUS
+                    - MUMBAI_IND
+                    - FRANKFURT_DEU
+                    - DUBLIN_IRL
+                    - LONDON_GBR
+                    - VIRGINIA_USA
+                    - OREGON_USA
+                    - SAOPAULO_BRA
+                    - SINGAPORE_SGP
+                    type: string
+                type: object
+              name:
+                type: string
+              privateEndpoints:
+                items:
+                  properties:
+                    endpointId:
+                      type: string
+                    provider:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              projectRef:
+                description: Project is a reference to AtlasProject resource the deployment
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              storage:
+                properties:
+                  databases:
+                    items:
+                      properties:
+                        collections:
+                          items:
+                            properties:
+                              dataSources:
+                                items:
+                                  properties:
+                                    allowInsecure:
+                                      type: boolean
+                                    collection:
+                                      type: string
+                                    collectionRegex:
+                                      type: string
+                                    database:
+                                      type: string
+                                    databaseRegex:
+                                      type: string
+                                    defaultFormat:
+                                      enum:
+                                      - .avro
+                                      - .avro.bz2
+                                      - .avro.gz
+                                      - .bson
+                                      - .bson.bz2
+                                      - .bson.gz
+                                      - .bsonx
+                                      - .csv
+                                      - .csv.bz2
+                                      - .csv.gz
+                                      - .json
+                                      - .json.bz2
+                                      - .json.gz
+                                      - .orc
+                                      - .parquet
+                                      - .tsv
+                                      - .tsv.bz2
+                                      - .tsv.gz
+                                      type: string
+                                    path:
+                                      type: string
+                                    provenanceFieldName:
+                                      type: string
+                                    storeName:
+                                      type: string
+                                    urls:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        maxWildcardCollections:
+                          type: integer
+                        name:
+                          type: string
+                        views:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              pipeline:
+                                type: string
+                              source:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  stores:
+                    items:
+                      properties:
+                        additionalStorageClasses:
+                          items:
+                            type: string
+                          type: array
+                        bucket:
+                          type: string
+                        delimiter:
+                          type: string
+                        includeTags:
+                          type: boolean
+                        name:
+                          type: string
+                        prefix:
+                          type: string
+                        provider:
+                          type: string
+                        public:
+                          type: boolean
+                        region:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdeployments.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasdeployments.yaml
@@ -1,0 +1,1120 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdeployments.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDeployment
+    listKind: AtlasDeploymentList
+    plural: atlasdeployments
+    shortNames:
+    - ad
+    singular: atlasdeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.stateName
+      name: Atlas State
+      type: string
+    - jsonPath: .status.mongoDBVersion
+      name: MongoDB Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDeployment is the Schema for the atlasdeployments API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AtlasDeploymentSpec defines the desired state of AtlasDeployment
+              Only one of DeploymentSpec, AdvancedDeploymentSpec and ServerlessSpec should be defined
+            properties:
+              backupRef:
+                description: Backup schedule for the AtlasDeployment
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              deploymentSpec:
+                description: Configuration for the advanced (v1.5) deployment API
+                  https://www.mongodb.com/docs/atlas/reference/api/clusters/
+                properties:
+                  backupEnabled:
+                    description: |-
+                      Applicable only for M10+ deployments.
+                      Flag that indicates if the deployment uses Cloud Backups for backups.
+                    type: boolean
+                  biConnector:
+                    description: |-
+                      Configuration of BI Connector for Atlas on this deployment.
+                      The MongoDB Connector for Business Intelligence for Atlas (BI Connector) is only available for M10 and larger deployments.
+                    properties:
+                      enabled:
+                        description: Flag that indicates whether or not BI Connector
+                          for Atlas is enabled on the deployment.
+                        type: boolean
+                      readPreference:
+                        description: Source from which the BI Connector for Atlas
+                          reads data. Each BI Connector for Atlas read preference
+                          contains a distinct combination of readPreference and readPreferenceTags
+                          options.
+                        type: string
+                    type: object
+                  clusterType:
+                    description: |-
+                      Type of the deployment that you want to create.
+                      The parameter is required if replicationSpecs are set or if Global Deployments are deployed.
+                    enum:
+                    - REPLICASET
+                    - SHARDED
+                    - GEOSHARDED
+                    type: string
+                  customZoneMapping:
+                    items:
+                      properties:
+                        location:
+                          type: string
+                        zone:
+                          type: string
+                      required:
+                      - location
+                      - zone
+                      type: object
+                    type: array
+                  diskSizeGB:
+                    description: |-
+                      Capacity, in gigabytes, of the host's root volume.
+                      Increase this number to add capacity, up to a maximum possible value of 4096 (i.e., 4 TB).
+                      This value must be a positive integer.
+                      The parameter is required if replicationSpecs are configured.
+                    maximum: 4096
+                    minimum: 0
+                    type: integer
+                  encryptionAtRestProvider:
+                    description: Cloud service provider that offers Encryption at
+                      Rest.
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - NONE
+                    type: string
+                  labels:
+                    description: |-
+                      Collection of key-value pairs that tag and categorize the deployment.
+                      Each key and value has a maximum length of 255 characters.
+                    items:
+                      description: LabelSpec contains key-value pairs that tag and
+                        categorize the Cluster/DBUser
+                      properties:
+                        key:
+                          maxLength: 255
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  managedNamespaces:
+                    items:
+                      description: ManagedNamespace represents the information about
+                        managed namespace configuration.
+                      properties:
+                        collection:
+                          type: string
+                        customShardKey:
+                          type: string
+                        db:
+                          type: string
+                        isCustomShardKeyHashed:
+                          type: boolean
+                        isShardKeyUnique:
+                          type: boolean
+                        numInitialChunks:
+                          type: integer
+                        presplitHashedZones:
+                          type: boolean
+                      required:
+                      - collection
+                      - db
+                      type: object
+                    type: array
+                  mongoDBMajorVersion:
+                    description: Version of the deployment to deploy.
+                    type: string
+                  mongoDBVersion:
+                    type: string
+                  name:
+                    description: |-
+                      Name of the advanced deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  paused:
+                    description: Flag that indicates whether the deployment should
+                      be paused.
+                    type: boolean
+                  pitEnabled:
+                    description: Flag that indicates the deployment uses continuous
+                      cloud backups.
+                    type: boolean
+                  replicationSpecs:
+                    description: Configuration for deployment regions.
+                    items:
+                      properties:
+                        numShards:
+                          description: |-
+                            Positive integer that specifies the number of shards to deploy in each specified zone.
+                            If you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.
+                            Don't create a sharded cluster with a single shard for production environments.
+                            Single-shard sharded clusters don't provide the same benefits as multi-shard configurations
+                          type: integer
+                        regionConfigs:
+                          description: |-
+                            Hardware specifications for nodes set for a given region.
+                            Each regionConfigs object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region.
+                            Each regionConfigs object must have either an analyticsSpecs object, electableSpecs object, or readOnlySpecs object.
+                            Tenant clusters only require electableSpecs. Dedicated clusters can specify any of these specifications, but must have at least one electableSpecs object within a replicationSpec.
+                            Every hardware specification must use the same instanceSize.
+                          items:
+                            properties:
+                              analyticsSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              autoScaling:
+                                description: AdvancedAutoScalingSpec configures your
+                                  deployment to automatically scale its storage
+                                properties:
+                                  compute:
+                                    description: Collection of settings that configure
+                                      how a deployment might scale its deployment
+                                      tier and whether the deployment can scale down.
+                                    properties:
+                                      enabled:
+                                        description: Flag that indicates whether deployment
+                                          tier auto-scaling is enabled. The default
+                                          is false.
+                                        type: boolean
+                                      maxInstanceSize:
+                                        description: 'Maximum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M40). Atlas requires this parameter
+                                          if "autoScaling.compute.enabled" : true.'
+                                        type: string
+                                      minInstanceSize:
+                                        description: 'Minimum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M10). Atlas requires this parameter
+                                          if "autoScaling.compute.scaleDownEnabled"
+                                          : true.'
+                                        type: string
+                                      scaleDownEnabled:
+                                        description: 'Flag that indicates whether
+                                          the deployment tier may scale down. Atlas
+                                          requires this parameter if "autoScaling.compute.enabled"
+                                          : true.'
+                                        type: boolean
+                                    type: object
+                                  diskGB:
+                                    description: Flag that indicates whether disk
+                                      auto-scaling is enabled. The default is true.
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              backingProviderName:
+                                description: |-
+                                  Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                                  This setting only works when "providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                                  Otherwise it should be equal to "providerName" value
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                type: string
+                              electableSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              priority:
+                                description: |-
+                                  Precedence is given to this region when a primary election occurs.
+                                  If your regionConfigs has only readOnlySpecs, analyticsSpecs, or both, set this value to 0.
+                                  If you have multiple regionConfigs objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order.
+                                  The highest priority is 7
+                                type: integer
+                              providerName:
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                - TENANT
+                                - SERVERLESS
+                                type: string
+                              readOnlySpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              regionName:
+                                description: |-
+                                  Physical location of your MongoDB deployment.
+                                  The region you choose can affect network latency for clients accessing your databases.
+                                type: string
+                            type: object
+                          type: array
+                        zoneName:
+                          description: Human-readable label that identifies the zone
+                            in a Global Cluster.
+                          type: string
+                      type: object
+                    type: array
+                  rootCertType:
+                    type: string
+                  searchIndexes:
+                    description: A list of atlas search indexes configuration for
+                      the current deployment
+                    items:
+                      description: SearchIndex is the CRD to configure part of the
+                        Atlas Search Index
+                      properties:
+                        DBName:
+                          description: Human-readable label that identifies the database
+                            that contains the collection with one or more Atlas Search
+                            indexes
+                          type: string
+                        collectionName:
+                          description: Human-readable label that identifies the collection
+                            that contains one or more Atlas Search indexes
+                          type: string
+                        name:
+                          description: Human-readable label that identifies this index.
+                            Must be unique for a deployment
+                          type: string
+                        search:
+                          description: Atlas search index configuration
+                          properties:
+                            mappings:
+                              description: Index specifications for the collection's
+                                fields
+                              properties:
+                                dynamic:
+                                  description: Flag that indicates whether the index
+                                    uses dynamic or static mappings. Required if mapping.fields
+                                    is omitted.
+                                  type: boolean
+                                fields:
+                                  description: One or more field specifications for
+                                    the Atlas Search index. Required if mapping.dynamic
+                                    is omitted or set to false.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            searchConfigurationRef:
+                              description: A reference to the AtlasSearchIndexConfig
+                                custom resource
+                              properties:
+                                name:
+                                  description: Name is the name of the Kubernetes
+                                    Resource
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of the Kubernetes
+                                    Resource
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            synonyms:
+                              description: Rule sets that map words to their synonyms
+                                in this index
+                              items:
+                                description: Synonym represents "Synonym" type of
+                                  Atlas Search Index
+                                properties:
+                                  analyzer:
+                                    description: Specific pre-defined method chosen
+                                      to apply to the synonyms to be searched
+                                    enum:
+                                    - lucene.standard
+                                    - lucene.standard
+                                    - lucene.simple
+                                    - lucene.whitespace
+                                    - lucene.keyword
+                                    - lucene.arabic
+                                    - lucene.armenian
+                                    - lucene.basque
+                                    - lucene.bengali
+                                    - lucene.brazilian
+                                    - lucene.bulgarian
+                                    - lucene.catalan
+                                    - lucene.chinese
+                                    - lucene.cjk
+                                    - lucene.czech
+                                    - lucene.danish
+                                    - lucene.dutch
+                                    - lucene.english
+                                    - lucene.finnish
+                                    - lucene.french
+                                    - lucene.galician
+                                    - lucene.german
+                                    - lucene.greek
+                                    - lucene.hindi
+                                    - lucene.hungarian
+                                    - lucene.indonesian
+                                    - lucene.irish
+                                    - lucene.italian
+                                    - lucene.japanese
+                                    - lucene.korean
+                                    - lucene.kuromoji
+                                    - lucene.latvian
+                                    - lucene.lithuanian
+                                    - lucene.morfologik
+                                    - lucene.nori
+                                    - lucene.norwegian
+                                    - lucene.persian
+                                    - lucene.portuguese
+                                    - lucene.romanian
+                                    - lucene.russian
+                                    - lucene.smartcn
+                                    - lucene.sorani
+                                    - lucene.spanish
+                                    - lucene.swedish
+                                    - lucene.thai
+                                    - lucene.turkish
+                                    - lucene.ukrainian
+                                    type: string
+                                  name:
+                                    description: Human-readable label that identifies
+                                      the synonym definition. Each name must be unique
+                                      within the same index definition
+                                    type: string
+                                  source:
+                                    description: Data set that stores the mapping
+                                      one or more words map to one or more synonyms
+                                      of those words
+                                    properties:
+                                      collection:
+                                        description: Human-readable label that identifies
+                                          the MongoDB collection that stores words
+                                          and their applicable synonyms
+                                        type: string
+                                    required:
+                                    - collection
+                                    type: object
+                                required:
+                                - analyzer
+                                - name
+                                - source
+                                type: object
+                              type: array
+                          required:
+                          - mappings
+                          - searchConfigurationRef
+                          type: object
+                        type:
+                          description: Type of the index
+                          enum:
+                          - search
+                          - vectorSearch
+                          type: string
+                        vectorSearch:
+                          description: Atlas vector search index configuration
+                          properties:
+                            fields:
+                              description: Array of JSON objects. See examples https://dochub.mongodb.org/core/avs-vector-type
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - fields
+                          type: object
+                      required:
+                      - DBName
+                      - collectionName
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  searchNodes:
+                    description: Settings for Search Nodes for the cluster. Currently,
+                      at most one search node configuration may be defined.
+                    items:
+                      properties:
+                        instanceSize:
+                          description: Hardware specification for the Search Node
+                            instance sizes.
+                          enum:
+                          - S20_HIGHCPU_NVME
+                          - S30_HIGHCPU_NVME
+                          - S40_HIGHCPU_NVME
+                          - S50_HIGHCPU_NVME
+                          - S60_HIGHCPU_NVME
+                          - S70_HIGHCPU_NVME
+                          - S80_HIGHCPU_NVME
+                          - S30_LOWCPU_NVME
+                          - S40_LOWCPU_NVME
+                          - S50_LOWCPU_NVME
+                          - S60_LOWCPU_NVME
+                          - S80_LOWCPU_NVME
+                          - S90_LOWCPU_NVME
+                          - S100_LOWCPU_NVME
+                          - S110_LOWCPU_NVME
+                          type: string
+                        nodeCount:
+                          description: Number of Search Nodes in the cluster.
+                          maximum: 32
+                          minimum: 2
+                          type: integer
+                      type: object
+                    maxItems: 1
+                    type: array
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                  versionReleaseSystem:
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: ExternalProjectRef holds the Atlas project ID the user
+                  belongs to
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              processArgs:
+                description: ProcessArgs allows to modify Advanced Configuration Options
+                properties:
+                  defaultReadConcern:
+                    type: string
+                  defaultWriteConcern:
+                    type: string
+                  failIndexKeyTooLong:
+                    type: boolean
+                  javascriptEnabled:
+                    type: boolean
+                  minimumEnabledTlsProtocol:
+                    type: string
+                  noTableScan:
+                    type: boolean
+                  oplogMinRetentionHours:
+                    type: string
+                  oplogSizeMB:
+                    format: int64
+                    type: integer
+                  sampleRefreshIntervalBIConnector:
+                    format: int64
+                    type: integer
+                  sampleSizeBIConnector:
+                    format: int64
+                    type: integer
+                type: object
+              projectRef:
+                description: Project is a reference to AtlasProject resource the deployment
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              serverlessSpec:
+                description: Configuration for the serverless deployment API. https://www.mongodb.com/docs/atlas/reference/api/serverless-instances/
+                properties:
+                  backupOptions:
+                    description: Serverless Backup Options
+                    properties:
+                      serverlessContinuousBackupEnabled:
+                        default: true
+                        description: ServerlessContinuousBackupEnabled
+                        type: boolean
+                    type: object
+                  name:
+                    description: |-
+                      Name of the serverless deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  privateEndpoints:
+                    items:
+                      properties:
+                        cloudProviderEndpointID:
+                          description: CloudProviderEndpointID is the identifier of
+                            the cloud provider endpoint.
+                          type: string
+                        name:
+                          description: Name is the name of the Serverless PrivateLink
+                            Service. Should be unique.
+                          type: string
+                        privateEndpointIpAddress:
+                          description: PrivateEndpointIPAddress is the IPv4 address
+                            of the private endpoint in your Azure VNet that someone
+                            added to this private endpoint service.
+                          type: string
+                      type: object
+                    type: array
+                  providerSettings:
+                    description: Configuration for the provisioned hosts on which
+                      MongoDB runs. The available options are specific to the cloud
+                      service provider.
+                    properties:
+                      autoScaling:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Range of instance sizes to which your deployment
+                          can scale.
+                        properties:
+                          autoIndexingEnabled:
+                            description: |-
+                              Deprecated: This flag is not supported anymore.
+                              Flag that indicates whether autopilot mode for Performance Advisor is enabled.
+                              The default is false.
+                            type: boolean
+                          compute:
+                            description: Collection of settings that configure how
+                              a deployment might scale its deployment tier and whether
+                              the deployment can scale down.
+                            properties:
+                              enabled:
+                                description: Flag that indicates whether deployment
+                                  tier auto-scaling is enabled. The default is false.
+                                type: boolean
+                              maxInstanceSize:
+                                description: 'Maximum instance size to which your
+                                  deployment can automatically scale (such as M40).
+                                  Atlas requires this parameter if "autoScaling.compute.enabled"
+                                  : true.'
+                                type: string
+                              minInstanceSize:
+                                description: 'Minimum instance size to which your
+                                  deployment can automatically scale (such as M10).
+                                  Atlas requires this parameter if "autoScaling.compute.scaleDownEnabled"
+                                  : true.'
+                                type: string
+                              scaleDownEnabled:
+                                description: 'Flag that indicates whether the deployment
+                                  tier may scale down. Atlas requires this parameter
+                                  if "autoScaling.compute.enabled" : true.'
+                                type: boolean
+                            type: object
+                          diskGBEnabled:
+                            description: Flag that indicates whether disk auto-scaling
+                              is enabled. The default is true.
+                            type: boolean
+                        type: object
+                      backingProviderName:
+                        description: |-
+                          Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                          This setting only works when "providerSetting.providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        type: string
+                      diskIOPS:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        format: int64
+                        type: integer
+                      diskTypeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Type of disk if you selected Azure as your
+                          cloud service provider.
+                        type: string
+                      encryptEBSVolume:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Flag that indicates whether the Amazon
+                          EBS encryption feature encrypts the host's root volume for
+                          both data at rest within the volume and for data moving
+                          between the volume and the deployment.
+                        type: boolean
+                      instanceSizeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Atlas provides different deployment tiers,
+                          each with a default storage capacity and RAM size. The deployment
+                          you select is used for all the data-bearing hosts in your
+                          deployment tier.
+                        type: string
+                      providerName:
+                        description: Cloud service provider on which Atlas provisions
+                          the hosts.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        - TENANT
+                        - SERVERLESS
+                        type: string
+                      regionName:
+                        description: |-
+                          Physical location of your MongoDB deployment.
+                          The region you choose can affect network latency for clients accessing your databases.
+                        type: string
+                      volumeType:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        enum:
+                        - STANDARD
+                        - PROVISIONED
+                        type: string
+                    required:
+                    - providerName
+                    type: object
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                required:
+                - name
+                - providerSettings
+                type: object
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDeploymentStatus defines the observed state of AtlasDeployment.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectionStrings:
+                description: ConnectionStrings is a set of connection strings that
+                  your applications use to connect to this cluster.
+                properties:
+                  private:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                    type: string
+                  privateEndpoint:
+                    description: |-
+                      Private endpoint connection strings.
+                      Each object describes the connection strings you can use to connect to this cluster through a private endpoint.
+                      Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                    items:
+                      description: |-
+                        PrivateEndpoint connection strings. Each object describes the connection strings
+                        you can use to connect to this cluster through a private endpoint.
+                        Atlas returns this parameter only if you deployed a private endpoint to all regions
+                        to which you deployed this cluster's nodes.
+                      properties:
+                        connectionString:
+                          description: Private-endpoint-aware mongodb:// connection
+                            string for this private endpoint.
+                          type: string
+                        endpoints:
+                          description: Private endpoint through which you connect
+                            to Atlas when you use connectionStrings.privateEndpoint[n].connectionString
+                            or connectionStrings.privateEndpoint[n].srvConnectionString.
+                          items:
+                            description: Endpoint through which you connect to Atlas
+                            properties:
+                              endpointId:
+                                description: Unique identifier of the private endpoint.
+                                type: string
+                              ip:
+                                description: Private IP address of the private endpoint
+                                  network interface you created in your Azure VNet.
+                                type: string
+                              providerName:
+                                description: Cloud provider to which you deployed
+                                  the private endpoint. Atlas returns AWS or AZURE.
+                                type: string
+                              region:
+                                description: Region to which you deployed the private
+                                  endpoint.
+                                type: string
+                            type: object
+                          type: array
+                        srvConnectionString:
+                          description: Private-endpoint-aware mongodb+srv:// connection
+                            string for this private endpoint.
+                          type: string
+                        srvShardOptimizedConnectionString:
+                          type: string
+                        type:
+                          description: |-
+                            Type of MongoDB process that you connect to with the connection strings
+
+                            Atlas returns:
+
+                            • MONGOD for replica sets, or
+
+                            • MONGOS for sharded clusters
+                          type: string
+                      type: object
+                    type: array
+                  privateSrv:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb+srv:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                      Use this URI format if your driver supports it. If it doesn't, use connectionStrings.private.
+                    type: string
+                  standard:
+                    description: Public mongodb:// connection string for this cluster.
+                    type: string
+                  standardSrv:
+                    description: Public mongodb+srv:// connection string for this
+                      cluster.
+                    type: string
+                type: object
+              customZoneMapping:
+                properties:
+                  customZoneMapping:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  zoneMappingErrMessage:
+                    type: string
+                  zoneMappingState:
+                    type: string
+                type: object
+              managedNamespaces:
+                items:
+                  properties:
+                    collection:
+                      type: string
+                    customShardKey:
+                      type: string
+                    db:
+                      type: string
+                    errMessage:
+                      type: string
+                    isCustomShardKeyHashed:
+                      type: boolean
+                    isShardKeyUnique:
+                      type: boolean
+                    numInitialChunks:
+                      type: integer
+                    presplitHashedZones:
+                      type: boolean
+                    status:
+                      type: string
+                  required:
+                  - collection
+                  - db
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              mongoURIUpdated:
+                description: |-
+                  MongoURIUpdated is a timestamp in ISO 8601 date and time format in UTC when the connection string was last updated.
+                  The connection string changes if you update any of the other values.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              replicaSets:
+                items:
+                  properties:
+                    id:
+                      type: string
+                    zoneName:
+                      type: string
+                  required:
+                  - id
+                  type: object
+                type: array
+              searchIndexes:
+                description: SearchIndexes contains a list of search indexes statuses
+                  configured for a project
+                items:
+                  properties:
+                    ID:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - ID
+                  - message
+                  - name
+                  - status
+                  type: object
+                type: array
+              serverlessPrivateEndpoints:
+                items:
+                  properties:
+                    _id:
+                      description: ID is the identifier of the Serverless PrivateLink
+                        Service.
+                      type: string
+                    cloudProviderEndpointId:
+                      description: CloudProviderEndpointID is the identifier of the
+                        cloud provider endpoint.
+                      type: string
+                    endpointServiceName:
+                      description: EndpointServiceName is the name of the PrivateLink
+                        endpoint service in AWS. Returns null while the endpoint service
+                        is being created.
+                      type: string
+                    errorMessage:
+                      description: ErrorMessage is the error message if the Serverless
+                        PrivateLink Service failed to create or connect.
+                      type: string
+                    name:
+                      description: Name is the name of the Serverless PrivateLink
+                        Service. Should be unique.
+                      type: string
+                    privateEndpointIpAddress:
+                      description: PrivateEndpointIPAddress is the IPv4 address of
+                        the private endpoint in your Azure VNet that someone added
+                        to this private endpoint service.
+                      type: string
+                    privateLinkServiceResourceId:
+                      description: PrivateLinkServiceResourceID is the root-relative
+                        path that identifies the Azure Private Link Service that MongoDB
+                        Cloud manages. MongoDB Cloud returns null while it creates
+                        the endpoint service.
+                      type: string
+                    providerName:
+                      description: ProviderName is human-readable label that identifies
+                        the cloud provider. Values include AWS or AZURE.
+                      type: string
+                    status:
+                      description: Status of the AWS Serverless PrivateLink connection.
+                      type: string
+                  type: object
+                type: array
+              stateName:
+                description: |-
+                  StateName is the current state of the cluster.
+                  The possible states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasfederatedauths.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasfederatedauths.yaml
@@ -1,0 +1,201 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasfederatedauths.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasFederatedAuth
+    listKind: AtlasFederatedAuthList
+    plural: atlasfederatedauths
+    shortNames:
+    - afa
+    singular: atlasfederatedauth
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasFederatedAuth is the Schema for the Atlasfederatedauth API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              connectionSecretRef:
+                description: |-
+                  Connection secret with API credentials for configuring the federation.
+                  These credentials must have OrganizationOwner permissions.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              dataAccessIdentityProviders:
+                description: |-
+                  The collection of unique ids representing the identity providers that can be used for data access in this organization.
+                  Currently connected data access identity providers missing from the this field will be disconnected.
+                items:
+                  type: string
+                type: array
+              domainAllowList:
+                description: Approved domains that restrict users who can join the
+                  organization based on their email address.
+                items:
+                  type: string
+                type: array
+              domainRestrictionEnabled:
+                default: false
+                description: |-
+                  Prevent users in the federation from accessing organizations outside of the federation, and creating new organizations.
+                  This option applies to the entire federation.
+                  See more information at https://www.mongodb.com/docs/atlas/security/federation-advanced-options/#restrict-user-membership-to-the-federation
+                type: boolean
+              enabled:
+                default: false
+                type: boolean
+              postAuthRoleGrants:
+                description: Atlas roles that are granted to a user in this organization
+                  after authenticating.
+                items:
+                  type: string
+                type: array
+              roleMappings:
+                description: Map IDP groups to Atlas roles.
+                items:
+                  description: RoleMapping maps an external group from an identity
+                    provider to roles within Atlas.
+                  properties:
+                    externalGroupName:
+                      description: ExternalGroupName is the name of the IDP group
+                        to which this mapping applies.
+                      maxLength: 200
+                      minLength: 1
+                      type: string
+                    roleAssignments:
+                      description: RoleAssignments define the roles within projects
+                        that should be given to members of the group.
+                      items:
+                        properties:
+                          projectName:
+                            description: The Atlas project in the same org in which
+                              the role should be given.
+                            type: string
+                          role:
+                            description: The role in Atlas that should be given to
+                              group members.
+                            enum:
+                            - ORG_MEMBER
+                            - ORG_READ_ONLY
+                            - ORG_BILLING_ADMIN
+                            - ORG_GROUP_CREATOR
+                            - ORG_OWNER
+                            - ORG_BILLING_READ_ONLY
+                            - ORG_TEAM_MEMBERS_ADMIN
+                            - GROUP_AUTOMATION_ADMIN
+                            - GROUP_BACKUP_ADMIN
+                            - GROUP_MONITORING_ADMIN
+                            - GROUP_OWNER
+                            - GROUP_READ_ONLY
+                            - GROUP_USER_ADMIN
+                            - GROUP_BILLING_ADMIN
+                            - GROUP_DATA_ACCESS_ADMIN
+                            - GROUP_DATA_ACCESS_READ_ONLY
+                            - GROUP_DATA_ACCESS_READ_WRITE
+                            - GROUP_CHARTS_ADMIN
+                            - GROUP_CLUSTER_MANAGER
+                            - GROUP_SEARCH_INDEX_EDITOR
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ssoDebugEnabled:
+                default: false
+                type: boolean
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasipaccesslists.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasipaccesslists.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasipaccesslists.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasIPAccessList
+    listKind: AtlasIPAccessListList
+    plural: atlasipaccesslists
+    shortNames:
+    - aip
+    singular: atlasipaccesslist
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasIPAccessList is the Schema for the atlasipaccesslists API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasIPAccessListSpec defines the desired state of AtlasIPAccessList.
+            properties:
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              entries:
+                description: Entries is the list of IP Access to be managed
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Date and time after which Atlas deletes the temporary
+                        access list entry.
+                      format: date-time
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Only one of ipAddress, cidrBlock, or awsSecurityGroup
+                      may be set.
+                    rule: '!(has(self.ipAddress) && (has(self.cidrBlock) || has(self.awsSecurityGroup)))
+                      && !(has(self.cidrBlock) && has(self.awsSecurityGroup))'
+                minItems: 1
+                type: array
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - entries
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasIPAccessListStatus is the most recent observed status
+              of the AtlasIPAccessList cluster. Read-only.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              entries:
+                description: Status is the state of the ip access list
+                items:
+                  properties:
+                    entry:
+                      description: Entry is the ip access Atlas is managing
+                      type: string
+                    status:
+                      description: Status is the correspondent state of the entry
+                      type: string
+                  required:
+                  - entry
+                  - status
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasprivateendpoints.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasprivateendpoints.yaml
@@ -1,0 +1,329 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasprivateendpoints.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasPrivateEndpoint
+    listKind: AtlasPrivateEndpointList
+    plural: atlasprivateendpoints
+    shortNames:
+    - ape
+    singular: atlasprivateendpoint
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The AtlasPrivateEndpoint custom resource definition (CRD) defines a desired [Private Endpoint](https://www.mongodb.com/docs/atlas/security-private-endpoint/#std-label-private-endpoint-overview) configuration for an Atlas project.
+          It allows a private connection between your cloud provider and Atlas that doesn't send information through a public network.
+
+          You can use private endpoints to create a unidirectional connection to Atlas clusters from your virtual network.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasPrivateEndpointSpec is the specification of the desired
+              configuration of a project private endpoint
+            properties:
+              awsConfiguration:
+                description: AWSConfiguration is the specific AWS settings for the
+                  private endpoint
+                items:
+                  description: AWSPrivateEndpointConfiguration holds the AWS configuration
+                    done on customer network
+                  properties:
+                    id:
+                      description: ID that identifies the private endpoint's network
+                        interface that someone added to this private endpoint service.
+                      type: string
+                  required:
+                  - id
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
+              azureConfiguration:
+                description: AzureConfiguration is the specific Azure settings for
+                  the private endpoint
+                items:
+                  description: AzurePrivateEndpointConfiguration holds the Azure configuration
+                    done on customer network
+                  properties:
+                    id:
+                      description: ID that identifies the private endpoint's network
+                        interface that someone added to this private endpoint service.
+                      type: string
+                    ipAddress:
+                      description: IP address of the private endpoint in your Azure
+                        VNet that someone added to this private endpoint service.
+                      type: string
+                  required:
+                  - id
+                  - ipAddress
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: ExternalProject holds the Atlas project ID the user belongs
+                  to
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              gcpConfiguration:
+                description: GCPConfiguration is the specific Google Cloud settings
+                  for the private endpoint
+                items:
+                  description: GCPPrivateEndpointConfiguration holds the GCP configuration
+                    done on customer network
+                  properties:
+                    endpoints:
+                      description: Endpoints is the list of individual private endpoints
+                        that comprise this endpoint group.
+                      items:
+                        description: GCPPrivateEndpoint holds the GCP forwarding rules
+                          configured on customer network
+                        properties:
+                          ipAddress:
+                            description: IP address to which this Google Cloud consumer
+                              forwarding rule resolves.
+                            type: string
+                          name:
+                            description: Name that identifies the Google Cloud consumer
+                              forwarding rule that you created.
+                            type: string
+                        required:
+                        - ipAddress
+                        - name
+                        type: object
+                      type: array
+                    groupName:
+                      description: GroupName is the label that identifies a set of
+                        endpoints.
+                      type: string
+                    projectId:
+                      description: ProjectID that identifies the Google Cloud project
+                        in which you created the endpoints.
+                      type: string
+                  required:
+                  - endpoints
+                  - groupName
+                  - projectId
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - groupName
+                x-kubernetes-list-type: map
+              projectRef:
+                description: Project is a reference to AtlasProject resource the user
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              provider:
+                description: Name of the cloud service provider for which you want
+                  to create the private endpoint service.
+                enum:
+                - AWS
+                - GCP
+                - AZURE
+                type: string
+              region:
+                description: Region of the chosen cloud provider in which you want
+                  to create the private endpoint service.
+                type: string
+            required:
+            - provider
+            - region
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasPrivateEndpointStatus is the most recent observed status
+              of the AtlasPrivateEndpoint cluster. Read-only.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoints:
+                description: Endpoints are the status of the endpoints connected to
+                  the service
+                items:
+                  description: EndpointInterfaceStatus is the most recent observed
+                    status the interfaces attached to the configured service. Read-only.
+                  properties:
+                    ID:
+                      description: ID is the external identifier set on the specification
+                        to configure the interface
+                      type: string
+                    InterfaceStatus:
+                      description: InterfaceStatus is the state of the private endpoint
+                        interface
+                      type: string
+                    connectionName:
+                      description: ConnectionName is the label that Atlas generates
+                        that identifies the Azure private endpoint connection
+                      type: string
+                    error:
+                      description: Error is the description of the failure occurred
+                        when configuring the private endpoint
+                      type: string
+                    gcpForwardingRules:
+                      description: GCPForwardingRules is the status of the customer
+                        GCP private endpoint(forwarding rules)
+                      items:
+                        description: GCPForwardingRule is the most recent observed
+                          status the GCP forwarding rules configured for an interface.
+                          Read-only.
+                        properties:
+                          name:
+                            type: string
+                          status:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              error:
+                description: Error is the description of the failure occurred when
+                  configuring the private endpoint
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              resourceId:
+                description: ResourceID is the root-relative path that identifies
+                  of the Atlas Azure Private Link Service
+                type: string
+              serviceAttachmentNames:
+                description: ServiceAttachmentNames is the list of URLs that identifies
+                  endpoints that Atlas can use to access one service across the private
+                  connection
+                items:
+                  type: string
+                type: array
+              serviceId:
+                description: ServiceID is the unique identifier of the private endpoint
+                  service in Atlas
+                type: string
+              serviceName:
+                description: ServiceName is the unique identifier of the Amazon Web
+                  Services (AWS) PrivateLink endpoint service or Azure Private Link
+                  Service managed by Atlas
+                type: string
+              serviceStatus:
+                description: ServiceStatus is the state of the private endpoint service
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasprojects.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasprojects.yaml
@@ -1,0 +1,1558 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasprojects.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasProject
+    listKind: AtlasProjectList
+    plural: atlasprojects
+    shortNames:
+    - ap
+    singular: atlasproject
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.name
+      name: Atlas Name
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasProject is the Schema for the atlasprojects API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasProjectSpec defines the desired state of Project in
+              Atlas
+            properties:
+              alertConfigurationSyncEnabled:
+                description: |-
+                  AlertConfigurationSyncEnabled is a flag that enables/disables Alert Configurations sync for the current Project.
+                  If true - project alert configurations will be synced according to AlertConfigurations.
+                  If not - alert configurations will not be modified by the operator. They can be managed through API, cli, UI.
+                type: boolean
+              alertConfigurations:
+                description: AlertConfiguration is a list of Alert Configurations
+                  configured for the current Project.
+                items:
+                  properties:
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiTokenRef:
+                            description: Secret containing a Slack API token or Bot
+                              token. Populated for the SLACK notifications type. If
+                              the token later becomes invalid, Atlas sends an email
+                              to the project owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogAPIKeyRef:
+                            description: Secret containing a Datadog API Key. Found
+                              in the Datadog dashboard. Populated for the DATADOG
+                              notifications type.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow name in lower-case letters.
+                            type: string
+                          flowdockApiTokenRef:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKeyRef:
+                            description: OpsGenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKeyRef:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsSecretRef:
+                            description: Secret containing a VictorOps API key and
+                              Routing key. Populated for the VICTOR_OPS notifications
+                              type. If the key later becomes invalid, Atlas sends
+                              an email to the project owner and eventually removes
+                              the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      type: array
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              auditing:
+                description: Auditing represents MongoDB Maintenance Windows
+                properties:
+                  auditAuthorizationSuccess:
+                    description: 'Indicates whether the auditing system captures successful
+                      authentication attempts for audit filters using the "atype"
+                      : "authCheck" auditing event. For more information, see auditAuthorizationSuccess'
+                    type: boolean
+                  auditFilter:
+                    description: JSON-formatted audit filter used by the project
+                    type: string
+                  enabled:
+                    description: Denotes whether or not the project associated with
+                      the {GROUP-ID} has database auditing enabled.
+                    type: boolean
+                type: object
+              backupCompliancePolicyRef:
+                description: BackupCompliancePolicyRef is a reference to the backup
+                  compliance CR.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              cloudProviderAccessRoles:
+                description: |-
+                  CloudProviderAccessRoles is a list of Cloud Provider Access Roles configured for the current Project.
+                  Deprecated: This configuration was deprecated in favor of CloudProviderIntegrations
+                items:
+                  description: |-
+                    CloudProviderAccessRole define an integration to a cloud provider
+                    Deprecated: This type is deprecated in favor of CloudProviderIntegration
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations is a list of Cloud Provider
+                  Integration configured for the current Project.
+                items:
+                  description: CloudProviderIntegration define an integration to a
+                    cloud provider
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              connectionSecretRef:
+                description: |-
+                  ConnectionSecret is the name of the Kubernetes Secret which contains the information about the way to connect to
+                  Atlas (organization ID, API keys). The default Operator connection configuration will be used if not provided.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              customRoles:
+                description: The customRoles lets you create, and change custom roles
+                  in your cluster. Use custom roles to specify custom sets of actions
+                  that the Atlas built-in roles can't describe.
+                items:
+                  properties:
+                    actions:
+                      description: List of the individual privilege actions that the
+                        role grants.
+                      items:
+                        properties:
+                          name:
+                            description: Human-readable label that identifies the
+                              privilege action.
+                            type: string
+                          resources:
+                            description: List of resources on which you grant the
+                              action.
+                            items:
+                              properties:
+                                cluster:
+                                  description: Flag that indicates whether to grant
+                                    the action on the cluster resource. If true, MongoDB
+                                    Cloud ignores Database and Collection parameters.
+                                  type: boolean
+                                collection:
+                                  description: Human-readable label that identifies
+                                    the collection on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                                database:
+                                  description: Human-readable label that identifies
+                                    the database on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        - resources
+                        type: object
+                      type: array
+                    inheritedRoles:
+                      description: List of the built-in roles that this custom role
+                        inherits.
+                      items:
+                        properties:
+                          database:
+                            description: Human-readable label that identifies the
+                              database on which someone grants the action to one MongoDB
+                              user.
+                            type: string
+                          name:
+                            description: Human-readable label that identifies the
+                              role inherited.
+                            type: string
+                        required:
+                        - database
+                        - name
+                        type: object
+                      type: array
+                    name:
+                      description: Human-readable label that identifies the role.
+                        This name must be unique for this custom role in this project.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              encryptionAtRest:
+                description: EncryptionAtRest allows to set encryption for AWS, Azure
+                  and GCP providers
+                properties:
+                  awsKms:
+                    description: AwsKms specifies AWS KMS configuration details and
+                      whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      region:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the AccessKeyID,
+                          SecretAccessKey, CustomerMasterKeyID and RoleID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valid:
+                        type: boolean
+                    type: object
+                  azureKeyVault:
+                    description: AzureKeyVault specifies Azure Key Vault configuration
+                      details and whether Encryption at Rest is enabled for an Atlas
+                      project.
+                    properties:
+                      azureEnvironment:
+                        type: string
+                      clientID:
+                        type: string
+                      enabled:
+                        type: boolean
+                      resourceGroupName:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the SubscriptionID,
+                          KeyVaultName, KeyIdentifier, Secret fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tenantID:
+                        type: string
+                    type: object
+                  googleCloudKms:
+                    description: GoogleCloudKms specifies GCP KMS configuration details
+                      and whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      secretRef:
+                        description: A reference to as Secret containing the ServiceAccountKey,
+                          KeyVersionResourceID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                type: object
+              integrations:
+                description: Integrations is a list of MongoDB Atlas integrations
+                  for the project
+                items:
+                  properties:
+                    accountId:
+                      type: string
+                    apiKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    apiTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    channelName:
+                      type: string
+                    enabled:
+                      type: boolean
+                    flowName:
+                      type: string
+                    licenseKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    microsoftTeamsWebhookUrl:
+                      type: string
+                    name:
+                      type: string
+                    orgName:
+                      type: string
+                    passwordRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    readTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    region:
+                      type: string
+                    routingKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    scheme:
+                      type: string
+                    secretRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    serviceDiscovery:
+                      type: string
+                    serviceKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    teamName:
+                      type: string
+                    type:
+                      description: Third Party Integration type such as Slack, New
+                        Relic, etc
+                      enum:
+                      - PAGER_DUTY
+                      - SLACK
+                      - DATADOG
+                      - NEW_RELIC
+                      - OPS_GENIE
+                      - VICTOR_OPS
+                      - FLOWDOCK
+                      - WEBHOOK
+                      - MICROSOFT_TEAMS
+                      - PROMETHEUS
+                      type: string
+                    url:
+                      type: string
+                    username:
+                      type: string
+                    writeTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              maintenanceWindow:
+                description: |-
+                  MaintenanceWindow allows to specify a preferred time in the week to run maintenance operations. See more
+                  information at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+                properties:
+                  autoDefer:
+                    description: Flag indicating whether any scheduled project maintenance
+                      should be deferred automatically for one week.
+                    type: boolean
+                  dayOfWeek:
+                    description: |-
+                      Day of the week when you would like the maintenance window to start as a 1-based integer.
+                      Sunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    maximum: 7
+                    minimum: 1
+                    type: integer
+                  defer:
+                    description: |-
+                      Flag indicating whether the next scheduled project maintenance should be deferred for one week.
+                      Cannot be specified if startASAP is true
+                    type: boolean
+                  hourOfDay:
+                    description: |-
+                      Hour of the day when you would like the maintenance window to start.
+                      This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+                    maximum: 23
+                    minimum: 0
+                    type: integer
+                  startASAP:
+                    description: |-
+                      Flag indicating whether project maintenance has been directed to start immediately.
+                      Cannot be specified if defer is true
+                    type: boolean
+                type: object
+              name:
+                description: Name is the name of the Project that is created in Atlas
+                  by the Operator if it doesn't exist yet.
+                type: string
+              networkPeers:
+                description: NetworkPeers is a list of Network Peers configured for
+                  the current Project.
+                items:
+                  properties:
+                    accepterRegionName:
+                      description: AccepterRegionName is the provider region name
+                        of user's vpc.
+                      type: string
+                    atlasCidrBlock:
+                      description: Atlas CIDR. It needs to be set if ContainerID is
+                        not set.
+                      type: string
+                    awsAccountId:
+                      description: AccountID of the user's vpc.
+                      type: string
+                    azureDirectoryId:
+                      description: AzureDirectoryID is the unique identifier for an
+                        Azure AD directory.
+                      type: string
+                    azureSubscriptionId:
+                      description: AzureSubscriptionID is the unique identifier of
+                        the Azure subscription in which the VNet resides.
+                      type: string
+                    containerId:
+                      description: ID of the network peer container. If not set, operator
+                        will create a new container with ContainerRegion and AtlasCIDRBlock
+                        input.
+                      type: string
+                    containerRegion:
+                      description: ContainerRegion is the provider region name of
+                        Atlas network peer container. If not set, AccepterRegionName
+                        is used.
+                      type: string
+                    gcpProjectId:
+                      description: User GCP Project ID. Its applicable only for GCP.
+                      type: string
+                    networkName:
+                      description: GCP Network Peer Name. Its applicable only for
+                        GCP.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the provider. If not
+                        set, it will be set to "AWS".
+                      type: string
+                    resourceGroupName:
+                      description: ResourceGroupName is the name of your Azure resource
+                        group.
+                      type: string
+                    routeTableCidrBlock:
+                      description: User VPC CIDR.
+                      type: string
+                    vnetName:
+                      description: VNetName is name of your Azure VNet. Its applicable
+                        only for Azure.
+                      type: string
+                    vpcId:
+                      description: AWS VPC ID.
+                      type: string
+                  type: object
+                type: array
+              privateEndpoints:
+                description: PrivateEndpoints is a list of Private Endpoints configured
+                  for the current Project.
+                items:
+                  properties:
+                    endpointGroupName:
+                      description: Unique identifier of the endpoint group. The endpoint
+                        group encompasses all of the endpoints that you created in
+                        Google Cloud.
+                      type: string
+                    endpoints:
+                      description: Collection of individual private endpoints that
+                        comprise your endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            description: Forwarding rule that corresponds to the endpoint
+                              you created in Google Cloud.
+                            type: string
+                          ipAddress:
+                            description: Private IP address of the endpoint you created
+                              in Google Cloud.
+                            type: string
+                        type: object
+                      type: array
+                    gcpProjectId:
+                      description: Unique identifier of the Google Cloud project in
+                        which you created your endpoints.
+                      type: string
+                    id:
+                      description: Unique identifier of the private endpoint you created
+                        in your AWS VPC or Azure Vnet.
+                      type: string
+                    ip:
+                      description: Private IP address of the private endpoint network
+                        interface you created in your Azure VNet.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      - TENANT
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              projectIpAccessList:
+                description: |-
+                  ProjectIPAccessList allows to enable the IP Access List for the Project. See more information at
+                  https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              regionUsageRestrictions:
+                default: NONE
+                description: |-
+                  RegionUsageRestrictions designate the project's AWS region when using Atlas for Government.
+                  This parameter should not be used with commercial Atlas.
+                  In Atlas for Government, not setting this field (defaulting to NONE) means the project is restricted to COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                enum:
+                - NONE
+                - GOV_REGIONS_ONLY
+                - COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                type: string
+              settings:
+                description: Settings allow to set Project Settings for the project
+                properties:
+                  isCollectDatabaseSpecificsStatisticsEnabled:
+                    type: boolean
+                  isDataExplorerEnabled:
+                    type: boolean
+                  isExtendedStorageSizesEnabled:
+                    type: boolean
+                  isPerformanceAdvisorEnabled:
+                    type: boolean
+                  isRealtimePerformancePanelEnabled:
+                    type: boolean
+                  isSchemaAdvisorEnabled:
+                    type: boolean
+                type: object
+              teams:
+                description: Teams enable you to grant project access roles to multiple
+                  users.
+                items:
+                  properties:
+                    roles:
+                      description: Roles the users of the team has over the project
+                      items:
+                        enum:
+                        - GROUP_OWNER
+                        - GROUP_CLUSTER_MANAGER
+                        - GROUP_DATA_ACCESS_ADMIN
+                        - GROUP_DATA_ACCESS_READ_WRITE
+                        - GROUP_DATA_ACCESS_READ_ONLY
+                        - GROUP_READ_ONLY
+                        type: string
+                      minItems: 1
+                      type: array
+                    teamRef:
+                      description: Reference to the team which will assigned to the
+                        project
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - roles
+                  - teamRef
+                  type: object
+                type: array
+              withDefaultAlertsSettings:
+                default: true
+                description: Flag that indicates whether to create the new project
+                  with the default alert settings enabled. This parameter defaults
+                  to true
+                type: boolean
+              x509CertRef:
+                description: X509CertRef is the name of the Kubernetes Secret which
+                  contains PEM-encoded CA certificate
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - name
+            type: object
+          status:
+            description: AtlasProjectStatus defines the observed state of AtlasProject
+            properties:
+              alertConfigurations:
+                description: AlertConfigurations contains a list of alert configuration
+                  statuses
+                items:
+                  properties:
+                    acknowledgedUntil:
+                      description: The date through which the alert has been acknowledged.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgementComment:
+                      description: The comment left by the user who acknowledged the
+                        alert. Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgingUsername:
+                      description: The username of the user who acknowledged the alert.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    alertConfigId:
+                      description: ID of the alert configuration that triggered this
+                        alert.
+                      type: string
+                    clusterId:
+                      description: The ID of the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    clusterName:
+                      description: The name the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    created:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was created.
+                      type: string
+                    currentValue:
+                      description: CurrentValue represents current value of the metric
+                        that triggered the alert. Only present for alerts of type
+                        HOST_METRIC.
+                      properties:
+                        number:
+                          description: The value of the metric.
+                          type: string
+                        units:
+                          description: The units for the value. Depends on the type
+                            of metric.
+                          type: string
+                      type: object
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    errorMessage:
+                      description: ErrorMessage is massage if the alert configuration
+                        is in an incorrect state.
+                      type: string
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    groupId:
+                      description: Unique identifier of the project that owns this
+                        alert configuration.
+                      type: string
+                    hostId:
+                      description: ID of the host to which the metric pertains. Only
+                        present for alerts of type HOST, HOST_METRIC, and REPLICA_SET.
+                      type: string
+                    hostnameAndPort:
+                      description: The hostname and port of each host to which the
+                        alert applies. Only present for alerts of type HOST, HOST_METRIC,
+                        and REPLICA_SET.
+                      type: string
+                    id:
+                      description: Unique identifier.
+                      type: string
+                    lastNotified:
+                      description: When the last notification was sent for this alert.
+                        Only present if notifications have been sent.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricName:
+                      description: The name of the measurement whose value went outside
+                        the threshold. Only present if eventTypeName is set to OUTSIDE_METRIC_THRESHOLD.
+                      type: string
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiToken:
+                            description: Slack API token or Bot token. Populated for
+                              the SLACK notifications type. If the token later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the token.
+                            type: string
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogApiKey:
+                            description: Datadog API Key. Found in the Datadog dashboard.
+                              Populated for the DATADOG notifications type.
+                            type: string
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow namse in lower-case letters.
+                            type: string
+                          flowdockApiToken:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            type: string
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKey:
+                            description: Opsgenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            type: string
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKey:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsApiKey:
+                            description: VictorOps API key. Populated for the VICTOR_OPS
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the key.
+                            type: string
+                          victorOpsRoutingKey:
+                            description: VictorOps routing key. Populated for the
+                              VICTOR_OPS notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                        type: object
+                      type: array
+                    replicaSetName:
+                      description: Name of the replica set. Only present for alerts
+                        of type HOST, HOST_METRIC, BACKUP, and REPLICA_SET.
+                      type: string
+                    resolved:
+                      description: When the alert was closed. Only present if the
+                        status is CLOSED.
+                      type: string
+                    sourceTypeName:
+                      description: For alerts of the type BACKUP, the type of server
+                        being backed up.
+                      type: string
+                    status:
+                      description: 'The current state of the alert. Possible values
+                        are: TRACKING, OPEN, CLOSED, CANCELED'
+                      type: string
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                    updated:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was last updated.
+                      type: string
+                  type: object
+                type: array
+              authModes:
+                description: |-
+                  AuthModes contains a list of configured authentication modes
+                  "SCRAM" is default authentication method and requires a password for each user
+                  "X509" signifies that self-managed X.509 authentication is configured
+                items:
+                  type: string
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations contains a list of configured
+                  cloud provider access roles. AWS support only
+                items:
+                  properties:
+                    atlasAWSAccountArn:
+                      type: string
+                    atlasAssumedRoleExternalId:
+                      type: string
+                    authorizedDate:
+                      type: string
+                    createdDate:
+                      type: string
+                    errorMessage:
+                      type: string
+                    featureUsages:
+                      items:
+                        properties:
+                          featureId:
+                            type: string
+                          featureType:
+                            type: string
+                        type: object
+                      type: array
+                    iamAssumedRoleArn:
+                      type: string
+                    providerName:
+                      type: string
+                    roleId:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - atlasAssumedRoleExternalId
+                  - providerName
+                  type: object
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              customRoles:
+                description: CustomRoles contains a list of custom roles statuses
+                items:
+                  properties:
+                    error:
+                      description: The message when the custom role is in the FAILED
+                        status
+                      type: string
+                    name:
+                      description: Role name which is unique
+                      type: string
+                    status:
+                      description: The status of the given custom role (OK or FAILED)
+                      type: string
+                  required:
+                  - name
+                  - status
+                  type: object
+                type: array
+              expiredIpAccessList:
+                description: |-
+                  The list of IP Access List entries that are expired due to 'deleteAfterDate' being less than the current date.
+                  Note, that this field is updated by the Atlas Operator only after specification changes
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              id:
+                description: The ID of the Atlas Project
+                type: string
+              networkPeers:
+                description: The list of network peers that are configured for current
+                  project
+                items:
+                  properties:
+                    atlasGcpProjectId:
+                      description: ProjectID of Atlas container. Applicable only for
+                        GCP. It's needed to add network peer connection.
+                      type: string
+                    atlasNetworkName:
+                      description: Atlas Network Name. Applicable only for GCP. It's
+                        needed to add network peer connection.
+                      type: string
+                    connectionId:
+                      description: Unique identifier of the network peer connection.
+                        Applicable only for AWS.
+                      type: string
+                    containerId:
+                      description: ContainerID of Atlas network peer container.
+                      type: string
+                    errorMessage:
+                      description: Error state of the network peer. Applicable only
+                        for GCP.
+                      type: string
+                    errorState:
+                      description: Error state of the network peer. Applicable only
+                        for Azure.
+                      type: string
+                    errorStateName:
+                      description: Error state of the network peer. Applicable only
+                        for AWS.
+                      type: string
+                    gcpProjectId:
+                      description: ProjectID of the user's vpc. Applicable only for
+                        GCP.
+                      type: string
+                    id:
+                      description: Unique identifier for NetworkPeer.
+                      type: string
+                    providerName:
+                      description: Cloud provider for which you want to retrieve a
+                        network peer.
+                      type: string
+                    region:
+                      description: Region for which you want to create the network
+                        peer. It isn't needed for GCP
+                      type: string
+                    status:
+                      description: Status of the network peer. Applicable only for
+                        GCP and Azure.
+                      type: string
+                    statusName:
+                      description: Status of the network peer. Applicable only for
+                        AWS.
+                      type: string
+                    vpc:
+                      description: |-
+                        VPC is general purpose field for storing the name of the VPC.
+                        VPC is vpcID for AWS, user networkName for GCP, and vnetName for Azure.
+                      type: string
+                  required:
+                  - id
+                  - providerName
+                  - region
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              privateEndpoints:
+                description: The list of private endpoints configured for current
+                  project
+                items:
+                  properties:
+                    endpoints:
+                      description: Collection of individual GCP private endpoints
+                        that comprise your network endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            type: string
+                          ipAddress:
+                            type: string
+                          status:
+                            type: string
+                        required:
+                        - endpointName
+                        - ipAddress
+                        - status
+                        type: object
+                      type: array
+                    id:
+                      description: Unique identifier for AWS or AZURE Private Link
+                        Connection.
+                      type: string
+                    interfaceEndpointId:
+                      description: Unique identifier of the AWS or Azure Private Link
+                        Interface Endpoint.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                    serviceAttachmentNames:
+                      description: Unique alphanumeric and special character strings
+                        that identify the service attachments associated with the
+                        GCP Private Service Connect endpoint service.
+                      items:
+                        type: string
+                      type: array
+                    serviceName:
+                      description: Name of the AWS or Azure Private Link Service that
+                        Atlas manages.
+                      type: string
+                    serviceResourceId:
+                      description: Unique identifier of the Azure Private Link Service
+                        (for AWS the same as ID).
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              prometheus:
+                description: |-
+                  Prometheus contains the status for Prometheus integration
+                  including the prometheusDiscoveryURL
+                properties:
+                  prometheusDiscoveryURL:
+                    type: string
+                  scheme:
+                    type: string
+                type: object
+              teams:
+                description: Teams contains a list of teams assignment statuses
+                items:
+                  properties:
+                    id:
+                      type: string
+                    teamRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - teamRef
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
@@ -1,0 +1,287 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlassearchindexconfigs.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasSearchIndexConfig
+    listKind: AtlasSearchIndexConfigList
+    plural: atlassearchindexconfigs
+    shortNames:
+    - asic
+    singular: atlassearchindexconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analyzer:
+                description: |-
+                  Specific pre-defined method chosen to convert database field text into searchable words. This conversion reduces the text of fields into the smallest units of text. These units are called a term or token. This process, known as tokenization, involves a variety of changes made to the text in fields:
+                  - extracting words
+                  - removing punctuation
+                  - removing accents
+                  - hanging to lowercase
+                  - removing common words
+                  - reducing words to their root form (stemming)
+                  - changing words to their base form (lemmatization) MongoDB Cloud uses the selected process to build the Atlas Search index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              analyzers:
+                description: List of user-defined methods to convert database field
+                  text into searchable words
+                items:
+                  properties:
+                    charFilters:
+                      description: Filters that examine text one character at a time
+                        and perform filtering operations
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      description: |-
+                        Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings:
+                        "lucene.", "builtin.", "mongodb."
+                      type: string
+                    tokenFilters:
+                      description: |-
+                        Filter that performs operations such as:
+                        - Stemming, which reduces related words, such as "talking", "talked", and "talks" to their root word "talk".
+                        - Redaction, the removal of sensitive information from public documents
+                      x-kubernetes-preserve-unknown-fields: true
+                    tokenizer:
+                      description: Tokenizer that you want to use to create tokens.
+                        Tokens determine how Atlas Search splits up text into discrete
+                        chunks for indexing
+                      properties:
+                        group:
+                          description: Index of the character group within the matching
+                            expression to extract into tokens. Use `0` to extract
+                            all character groups.
+                          type: integer
+                        maxGram:
+                          description: Characters to include in the longest token
+                            that Atlas Search creates.
+                          type: integer
+                        maxTokenLength:
+                          description: Maximum number of characters in a single token.
+                            Tokens greater than this length are split at this length
+                            into multiple tokens.
+                          type: integer
+                        minGram:
+                          description: Characters to include in the shortest token
+                            that Atlas Search creates.
+                          type: integer
+                        pattern:
+                          description: Regular expression to match against.
+                          type: string
+                        type:
+                          description: Human-readable label that identifies this tokenizer
+                            type.
+                          enum:
+                          - whitespace
+                          - uaxUrlEmail
+                          - standard
+                          - regexSplit
+                          - regexCaptureGroup
+                          - nGram
+                          - keyword
+                          - edgeGram
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - tokenizer
+                  type: object
+                type: array
+              searchAnalyzer:
+                description: Method applied to identify words when searching this
+                  index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              storedSource:
+                description: |-
+                  Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search. Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation:
+                  https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasstreamconnections.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasstreamconnections.yaml
@@ -1,0 +1,242 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreamconnections.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamConnection
+    listKind: AtlasStreamConnectionList
+    plural: atlasstreamconnections
+    shortNames:
+    - asc
+    singular: atlasstreamconnection
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamConnection is the Schema for the atlasstreamconnections
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  name:
+                    description: Name of the cluster configured for this connection
+                    type: string
+                  role:
+                    description: The name of a Built in or Custom DB Role to connect
+                      to an Atlas Cluster
+                    properties:
+                      name:
+                        description: The name of the role to use. Can be a built in
+                          role or a custom role
+                        type: string
+                      type:
+                        description: Type of the DB role. Can be either BuiltIn or
+                          Custom
+                        enum:
+                        - BUILT_IN
+                        - CUSTOM
+                        type: string
+                    required:
+                    - name
+                    - type
+                    type: object
+                required:
+                - name
+                - role
+                type: object
+              kafkaConfig:
+                description: The configuration to be used to connect to a Kafka Cluster
+                properties:
+                  authentication:
+                    description: User credentials required to connect to a Kafka Cluster.
+                      Includes the authentication type, as well as the parameters
+                      for that authentication mode
+                    properties:
+                      credentials:
+                        description: Reference to the secret containing th Username
+                          and Password of the account to connect to the Kafka cluster.
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      mechanism:
+                        description: Style of authentication. Can be one of PLAIN,
+                          SCRAM-256, or SCRAM-512
+                        enum:
+                        - PLAIN
+                        - SCRAM-256
+                        - SCRAM-512
+                        type: string
+                    required:
+                    - credentials
+                    - mechanism
+                    type: object
+                  bootstrapServers:
+                    description: Comma separated list of server addresses
+                    type: string
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: A map of Kafka key-value pairs for optional configuration.
+                      This is a flat object, and keys can have '.' characters
+                    type: object
+                  security:
+                    description: Properties for the secure transport connection to
+                      Kafka. For SSL, this can include the trusted certificate to
+                      use
+                    properties:
+                      certificate:
+                        description: A trusted, public x509 certificate for connecting
+                          to Kafka over SSL
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      protocol:
+                        description: Describes the transport type. Can be either PLAINTEXT
+                          or SSL
+                        enum:
+                        - PLAINTEXT
+                        - SSL
+                        type: string
+                    required:
+                    - protocol
+                    type: object
+                required:
+                - authentication
+                - bootstrapServers
+                - security
+                type: object
+              name:
+                description: Human-readable label that uniquely identifies the stream
+                  connection
+                type: string
+              type:
+                description: Type of the connection. Can be either Cluster or Kafka
+                enum:
+                - Kafka
+                - Cluster
+                - Sample
+                type: string
+            required:
+            - name
+            - type
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: List of instances using the connection configuration
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasstreaminstances.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasstreaminstances.yaml
@@ -1,0 +1,213 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreaminstances.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamInstance
+    listKind: AtlasStreamInstanceList
+    plural: atlasstreaminstances
+    shortNames:
+    - asi
+    singular: atlasstreaminstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamInstance is the Schema for the atlasstreaminstances
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  provider:
+                    default: AWS
+                    description: Name of the cluster configured for this connection
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - TENANT
+                    - SERVERLESS
+                    type: string
+                  region:
+                    description: Name of the cloud provider region hosting Atlas Stream
+                      Processing.
+                    type: string
+                  tier:
+                    default: SP10
+                    description: Selected tier for the Stream Instance. Configures
+                      Memory / VCPU allowances.
+                    enum:
+                    - SP10
+                    - SP30
+                    - SP50
+                    type: string
+                required:
+                - provider
+                - region
+                - tier
+                type: object
+              connectionRegistry:
+                description: List of connections of the stream instance for the specified
+                  project
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Human-readable label that identifies the stream connection
+                type: string
+              projectRef:
+                description: Project which the instance belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - clusterConfig
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connections:
+                description: List of connections configured in the stream instance.
+                items:
+                  properties:
+                    name:
+                      description: Human-readable label that uniquely identifies the
+                        stream connection
+                      type: string
+                    resourceRef:
+                      description: Reference for the resource that contains connection
+                        configuration
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              hostnames:
+                description: List that contains the hostnames assigned to the stream
+                  instance.
+                items:
+                  type: string
+                type: array
+              id:
+                description: Unique 24-hexadecimal character string that identifies
+                  the instance
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasteams.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.6.0/atlas.mongodb.com_atlasteams.yaml
@@ -1,0 +1,144 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasteams.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasTeam
+    listKind: AtlasTeamList
+    plural: atlasteams
+    shortNames:
+    - at
+    singular: atlasteam
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasTeam is the Schema for the Atlas Teams API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TeamSpec defines the desired state of a Team in Atlas
+            properties:
+              name:
+                description: The name of the team you want to create.
+                type: string
+              usernames:
+                description: Valid email addresses of users to add to the new team
+                items:
+                  format: email
+                  type: string
+                type: array
+            required:
+            - name
+            - usernames
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                description: ID of the team
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              projects:
+                description: List of projects which the team is assigned
+                items:
+                  properties:
+                    id:
+                      description: Unique identifier of the project inside atlas
+                      type: string
+                    name:
+                      description: Name given to the project
+                      type: string
+                  required:
+                  - id
+                  - name
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackupcompliancepolicies.yaml
@@ -1,0 +1,235 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupcompliancepolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupCompliancePolicy
+    listKind: AtlasBackupCompliancePolicyList
+    plural: atlasbackupcompliancepolicies
+    shortNames:
+    - abcp
+    singular: atlasbackupcompliancepolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupCompliancePolicy defines the desired state of a compliance
+          policy in Atlas.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              authorizedEmail:
+                description: Email address of the user who authorized to update the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserFirstName:
+                description: First name of the user who authorized to updated the
+                  Backup Compliance Policy settings.
+                type: string
+              authorizedUserLastName:
+                description: Last name of the user who authorized to updated the Backup
+                  Compliance Policy settings.
+                type: string
+              copyProtectionEnabled:
+                description: Flag that indicates whether to prevent cluster users
+                  from deleting backups copied to other regions, even if those additional
+                  snapshot regions are removed.
+                type: boolean
+              encryptionAtRestEnabled:
+                description: Flag that indicates whether Encryption at Rest using
+                  Customer Key Management is required for all clusters with a Backup
+                  Compliance Policy.
+                type: boolean
+              onDemandPolicy:
+                description: Specifications for on-demand policy.
+                properties:
+                  retentionUnit:
+                    description: 'Scope of the backup policy item: days, weeks, or
+                      months'
+                    enum:
+                    - days
+                    - weeks
+                    - months
+                    type: string
+                  retentionValue:
+                    description: Value to associate with RetentionUnit
+                    type: integer
+                required:
+                - retentionUnit
+                - retentionValue
+                type: object
+              overwriteBackupPolicies:
+                description: Flag that indicates whether to overwrite non complying
+                  backup policies with the new data protection settings or not.
+                type: boolean
+              pointInTimeEnabled:
+                description: Flag that indicates whether the cluster uses Continuous
+                  Cloud Backups with a Backup Compliance Policy.
+                type: boolean
+              restoreWindowDays:
+                description: Number of previous days that you can restore back to
+                  with Continuous Cloud Backup with a Backup Compliance Policy. This
+                  parameter applies only to Continuous Cloud Backups with a Backup
+                  Compliance Policy.
+                type: integer
+              scheduledPolicyItems:
+                description: List that contains the specifications for one scheduled
+                  policy.
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - authorizedEmail
+            - authorizedUserFirstName
+            - authorizedUserLastName
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackuppolicies.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackuppolicies.yaml
@@ -1,0 +1,183 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackuppolicies.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupPolicy
+    listKind: AtlasBackupPolicyList
+    plural: atlasbackuppolicies
+    shortNames:
+    - abp
+    singular: atlasbackuppolicy
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupPolicy is the Schema for the atlasbackuppolicies API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupPolicySpec defines the desired state of AtlasBackupPolicy
+            properties:
+              items:
+                description: A list of BackupPolicy items
+                items:
+                  properties:
+                    frequencyInterval:
+                      description: |-
+                        Desired frequency of the new backup policy item specified by FrequencyType. A value of 1 specifies the first instance of the corresponding FrequencyType.
+                        The only accepted value you can set for frequency interval with NVMe clusters is 12.
+                      enum:
+                      - 1
+                      - 2
+                      - 3
+                      - 4
+                      - 5
+                      - 6
+                      - 7
+                      - 8
+                      - 9
+                      - 10
+                      - 11
+                      - 12
+                      - 13
+                      - 14
+                      - 15
+                      - 16
+                      - 17
+                      - 18
+                      - 19
+                      - 20
+                      - 21
+                      - 22
+                      - 23
+                      - 24
+                      - 25
+                      - 26
+                      - 27
+                      - 28
+                      - 40
+                      type: integer
+                    frequencyType:
+                      description: 'Frequency associated with the backup policy item.
+                        One of the following values: hourly, daily, weekly or monthly.
+                        You cannot specify multiple hourly and daily backup policy
+                        items.'
+                      enum:
+                      - hourly
+                      - daily
+                      - weekly
+                      - monthly
+                      - yearly
+                      type: string
+                    retentionUnit:
+                      description: 'Scope of the backup policy item: days, weeks,
+                        or months'
+                      enum:
+                      - days
+                      - weeks
+                      - months
+                      - years
+                      type: string
+                    retentionValue:
+                      description: Value to associate with RetentionUnit
+                      type: integer
+                  required:
+                  - frequencyInterval
+                  - frequencyType
+                  - retentionUnit
+                  - retentionValue
+                  type: object
+                type: array
+            required:
+            - items
+            type: object
+          status:
+            properties:
+              backupScheduleIDs:
+                description: DeploymentID of the deployment using the backup policy
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackupschedules.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasbackupschedules.yaml
@@ -1,0 +1,212 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasbackupschedules.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasBackupSchedule
+    listKind: AtlasBackupScheduleList
+    plural: atlasbackupschedules
+    shortNames:
+    - abs
+    singular: atlasbackupschedule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasBackupSchedule is the Schema for the atlasbackupschedules
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasBackupScheduleSpec defines the desired state of AtlasBackupSchedule
+            properties:
+              autoExportEnabled:
+                default: false
+                description: Specify true to enable automatic export of cloud backup
+                  snapshots to the AWS bucket. You must also define the export policy
+                  using export. If omitted, defaults to false.
+                type: boolean
+              copySettings:
+                description: Copy backups to other regions for increased resiliency
+                  and faster restores.
+                items:
+                  properties:
+                    cloudProvider:
+                      default: AWS
+                      description: Identifies the cloud provider that stores the snapshot
+                        copy.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      type: string
+                    frequencies:
+                      description: List that describes which types of snapshots to
+                        copy.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    regionName:
+                      description: Target region to copy snapshots belonging to replicationSpecId
+                        to.
+                      type: string
+                    shouldCopyOplogs:
+                      description: Flag that indicates whether to copy the oplogs
+                        to the target region.
+                      type: boolean
+                  type: object
+                type: array
+              export:
+                description: Export policy for automatically exporting cloud backup
+                  snapshots to AWS bucket.
+                properties:
+                  exportBucketId:
+                    description: Unique Atlas identifier of the AWS bucket which was
+                      granted access to export backup snapshot
+                    type: string
+                  frequencyType:
+                    default: monthly
+                    enum:
+                    - monthly
+                    type: string
+                required:
+                - exportBucketId
+                - frequencyType
+                type: object
+              policy:
+                description: A reference (name & namespace) for backup policy in the
+                  desired updated backup policy.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              referenceHourOfDay:
+                description: UTC Hour of day between 0 and 23, inclusive, representing
+                  which hour of the day that Atlas takes snapshots for backup policy
+                  items
+                format: int64
+                maximum: 23
+                minimum: 0
+                type: integer
+              referenceMinuteOfHour:
+                description: UTC Minutes after ReferenceHourOfDay that Atlas takes
+                  snapshots for backup policy items. Must be between 0 and 59, inclusive.
+                format: int64
+                maximum: 59
+                minimum: 0
+                type: integer
+              restoreWindowDays:
+                default: 1
+                description: Number of days back in time you can restore to with Continuous
+                  Cloud Backup accuracy. Must be a positive, non-zero integer. Applies
+                  to continuous cloud backups only.
+                format: int64
+                type: integer
+              updateSnapshots:
+                description: Specify true to apply the retention changes in the updated
+                  backup policy to snapshots that Atlas took previously.
+                type: boolean
+              useOrgAndGroupNamesInExportPrefix:
+                description: Specify true to use organization and project names instead
+                  of organization and project UUIDs in the path for the metadata files
+                  that Atlas uploads to your S3 bucket after it finishes exporting
+                  the snapshots
+                type: boolean
+            required:
+            - policy
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              deploymentID:
+                items:
+                  type: string
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlascustomroles.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlascustomroles.yaml
@@ -1,0 +1,223 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlascustomroles.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasCustomRole
+    listKind: AtlasCustomRoleList
+    plural: atlascustomroles
+    shortNames:
+    - acr
+    singular: atlascustomrole
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.role.name
+      name: Name
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasCustomRole is the Schema for the AtlasCustomRole API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasCustomRoleSpec defines the desired state of CustomRole
+              in Atlas
+            properties:
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              role:
+                properties:
+                  actions:
+                    description: List of the individual privilege actions that the
+                      role grants.
+                    items:
+                      properties:
+                        name:
+                          description: Human-readable label that identifies the privilege
+                            action.
+                          type: string
+                        resources:
+                          description: List of resources on which you grant the action.
+                          items:
+                            properties:
+                              cluster:
+                                description: Flag that indicates whether to grant
+                                  the action on the cluster resource. If true, MongoDB
+                                  Cloud ignores Database and Collection parameters.
+                                type: boolean
+                              collection:
+                                description: Human-readable label that identifies
+                                  the collection on which you grant the action to
+                                  one MongoDB user.
+                                type: string
+                              database:
+                                description: Human-readable label that identifies
+                                  the database on which you grant the action to one
+                                  MongoDB user.
+                                type: string
+                            type: object
+                          type: array
+                      required:
+                      - name
+                      - resources
+                      type: object
+                    type: array
+                  inheritedRoles:
+                    description: List of the built-in roles that this custom role
+                      inherits.
+                    items:
+                      properties:
+                        database:
+                          description: Human-readable label that identifies the database
+                            on which someone grants the action to one MongoDB user.
+                          type: string
+                        name:
+                          description: Human-readable label that identifies the role
+                            inherited.
+                          type: string
+                      required:
+                      - database
+                      - name
+                      type: object
+                    type: array
+                  name:
+                    description: Human-readable label that identifies the role. This
+                      name must be unique for this custom role in this project.
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - role
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: |-
+              AtlasCustomRoleStatus is a status for the AtlasCustomRole Custom resource.
+              Not the one included in the AtlasProject
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdatabaseusers.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdatabaseusers.yaml
@@ -1,0 +1,305 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatabaseusers.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDatabaseUser
+    listKind: AtlasDatabaseUserList
+    plural: atlasdatabaseusers
+    shortNames:
+    - adu
+    singular: atlasdatabaseuser
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.username
+      name: Username
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDatabaseUser is the Schema for the Atlas Database User API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasDatabaseUserSpec defines the desired state of Database
+              User in Atlas
+            properties:
+              awsIamType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database
+                  user authenticates with the Amazon Web Services (AWS)
+                  Identity and Access Management (IAM) credentials associated with
+                  the user or the user's role
+                enum:
+                - NONE
+                - USER
+                - ROLE
+                type: string
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              databaseName:
+                default: admin
+                description: |-
+                  DatabaseName is a Database against which Atlas authenticates the user.
+                  If the user authenticates with AWS IAM, x.509, LDAP, or OIDC Workload this value should be '$external'.
+                  If the user authenticates with SCRAM-SHA or OIDC Workforce, this value should be 'admin'.
+                  Default value is 'admin'.
+                type: string
+              deleteAfterDate:
+                description: |-
+                  DeleteAfterDate is a timestamp in ISO 8601 date and time format in UTC after which Atlas deletes the user.
+                  The specified date must be in the future and within one week.
+                type: string
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              labels:
+                description: |-
+                  Labels is an array containing key-value pairs that tag and categorize the database user.
+                  Each key and value has a maximum length of 255 characters.
+                items:
+                  description: LabelSpec contains key-value pairs that tag and categorize
+                    the Cluster/DBUser
+                  properties:
+                    key:
+                      maxLength: 255
+                      type: string
+                    value:
+                      type: string
+                  required:
+                  - key
+                  - value
+                  type: object
+                type: array
+              oidcAuthType:
+                default: NONE
+                description: |-
+                  Human-readable label that indicates whether the new database Username with OIDC federated authentication.
+                  To create a federated authentication group (Workforce), specify the value of IDP_GROUP in this field.
+                  To create a federated authentication user (Workload), specify the value of USER in this field.
+                enum:
+                - NONE
+                - IDP_GROUP
+                - USER
+                type: string
+              passwordSecretRef:
+                description: PasswordSecret is a reference to the Secret keeping the
+                  user password.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              roles:
+                description: |-
+                  Roles is an array of this user's roles and the databases / collections on which the roles apply. A role allows
+                  the user to perform particular actions on the specified database.
+                items:
+                  description: |-
+                    RoleSpec allows the user to perform particular actions on the specified database.
+                    A role on the admin database can include privileges that apply to the other databases as well.
+                  properties:
+                    collectionName:
+                      description: CollectionName is a collection for which the role
+                        applies.
+                      type: string
+                    databaseName:
+                      description: |-
+                        DatabaseName is a database on which the user has the specified role. A role on the admin database can include
+                        privileges that apply to the other databases.
+                      type: string
+                    roleName:
+                      description: RoleName is a name of the role. This value can
+                        either be a built-in role or a custom role.
+                      type: string
+                  required:
+                  - databaseName
+                  - roleName
+                  type: object
+                minItems: 1
+                type: array
+              scopes:
+                description: Scopes is an array of clusters and Atlas Data Lakes that
+                  this user has access to.
+                items:
+                  description: |-
+                    ScopeSpec if present a database user only have access to the indicated resource (Cluster or Atlas Data Lake)
+                    if none is given then it has access to all.
+                    It's highly recommended to restrict the access of the database users only to a limited set of resources.
+                  properties:
+                    name:
+                      description: Name is a name of the cluster or Atlas Data Lake
+                        that the user has access to.
+                      type: string
+                    type:
+                      description: Type is a type of resource that the user has access
+                        to.
+                      enum:
+                      - CLUSTER
+                      - DATA_LAKE
+                      type: string
+                  required:
+                  - name
+                  - type
+                  type: object
+                type: array
+              username:
+                description: |-
+                  Username is a username for authenticating to MongoDB
+                  Human-readable label that represents the user that authenticates to MongoDB. The format of this label depends on the method of authentication:
+                  In case of AWS IAM: the value should be AWS ARN for the IAM User/Role;
+                  In case of OIDC Workload or Workforce: the value should be the Atlas OIDC IdP ID, followed by a '/', followed by the IdP group name;
+                  In case of Plain text auth: the value can be anything
+                maxLength: 1024
+                type: string
+              x509Type:
+                default: NONE
+                description: X509Type is X.509 method by which the database authenticates
+                  the provided username
+                enum:
+                - NONE
+                - MANAGED
+                - CUSTOMER
+                type: string
+            required:
+            - roles
+            - username
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDatabaseUserStatus defines the observed state of AtlasProject
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              name:
+                description: UserName is the current name of database user.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              passwordVersion:
+                description: PasswordVersion is the 'ResourceVersion' of the password
+                  Secret that the Atlas Operator is aware of
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdatafederations.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdatafederations.yaml
@@ -1,0 +1,272 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdatafederations.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDataFederation
+    listKind: AtlasDataFederationList
+    plural: atlasdatafederations
+    shortNames:
+    - adf
+    singular: atlasdatafederation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDataFederation is the Schema for the Atlas Data Federation
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              cloudProviderConfig:
+                properties:
+                  aws:
+                    properties:
+                      roleId:
+                        type: string
+                      testS3Bucket:
+                        type: string
+                    type: object
+                type: object
+              dataProcessRegion:
+                properties:
+                  cloudProvider:
+                    enum:
+                    - AWS
+                    type: string
+                  region:
+                    enum:
+                    - SYDNEY_AUS
+                    - MUMBAI_IND
+                    - FRANKFURT_DEU
+                    - DUBLIN_IRL
+                    - LONDON_GBR
+                    - VIRGINIA_USA
+                    - OREGON_USA
+                    - SAOPAULO_BRA
+                    - SINGAPORE_SGP
+                    type: string
+                type: object
+              name:
+                type: string
+              privateEndpoints:
+                items:
+                  properties:
+                    endpointId:
+                      type: string
+                    provider:
+                      type: string
+                    type:
+                      type: string
+                  type: object
+                type: array
+              projectRef:
+                description: Project is a reference to AtlasProject resource the deployment
+                  belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              storage:
+                properties:
+                  databases:
+                    items:
+                      properties:
+                        collections:
+                          items:
+                            properties:
+                              dataSources:
+                                items:
+                                  properties:
+                                    allowInsecure:
+                                      type: boolean
+                                    collection:
+                                      type: string
+                                    collectionRegex:
+                                      type: string
+                                    database:
+                                      type: string
+                                    databaseRegex:
+                                      type: string
+                                    defaultFormat:
+                                      enum:
+                                      - .avro
+                                      - .avro.bz2
+                                      - .avro.gz
+                                      - .bson
+                                      - .bson.bz2
+                                      - .bson.gz
+                                      - .bsonx
+                                      - .csv
+                                      - .csv.bz2
+                                      - .csv.gz
+                                      - .json
+                                      - .json.bz2
+                                      - .json.gz
+                                      - .orc
+                                      - .parquet
+                                      - .tsv
+                                      - .tsv.bz2
+                                      - .tsv.gz
+                                      type: string
+                                    path:
+                                      type: string
+                                    provenanceFieldName:
+                                      type: string
+                                    storeName:
+                                      type: string
+                                    urls:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        maxWildcardCollections:
+                          type: integer
+                        name:
+                          type: string
+                        views:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              pipeline:
+                                type: string
+                              source:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  stores:
+                    items:
+                      properties:
+                        additionalStorageClasses:
+                          items:
+                            type: string
+                          type: array
+                        bucket:
+                          type: string
+                        delimiter:
+                          type: string
+                        includeTags:
+                          type: boolean
+                        name:
+                          type: string
+                        prefix:
+                          type: string
+                        provider:
+                          type: string
+                        public:
+                          type: boolean
+                        region:
+                          type: string
+                      type: object
+                    type: array
+                type: object
+            required:
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdeployments.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasdeployments.yaml
@@ -1,0 +1,1191 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasdeployments.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasDeployment
+    listKind: AtlasDeploymentList
+    plural: atlasdeployments
+    shortNames:
+    - ad
+    singular: atlasdeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.stateName
+      name: Atlas State
+      type: string
+    - jsonPath: .status.mongoDBVersion
+      name: MongoDB Version
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasDeployment is the Schema for the atlasdeployments API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              AtlasDeploymentSpec defines the desired state of AtlasDeployment
+              Only one of DeploymentSpec, AdvancedDeploymentSpec and ServerlessSpec should be defined
+            properties:
+              backupRef:
+                description: Backup schedule for the AtlasDeployment
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              deploymentSpec:
+                description: Configuration for the advanced (v1.5) deployment API
+                  https://www.mongodb.com/docs/atlas/reference/api/clusters/
+                properties:
+                  backupEnabled:
+                    description: |-
+                      Applicable only for M10+ deployments.
+                      Flag that indicates if the deployment uses Cloud Backups for backups.
+                    type: boolean
+                  biConnector:
+                    description: |-
+                      Configuration of BI Connector for Atlas on this deployment.
+                      The MongoDB Connector for Business Intelligence for Atlas (BI Connector) is only available for M10 and larger deployments.
+                    properties:
+                      enabled:
+                        description: Flag that indicates whether or not BI Connector
+                          for Atlas is enabled on the deployment.
+                        type: boolean
+                      readPreference:
+                        description: Source from which the BI Connector for Atlas
+                          reads data. Each BI Connector for Atlas read preference
+                          contains a distinct combination of readPreference and readPreferenceTags
+                          options.
+                        type: string
+                    type: object
+                  clusterType:
+                    description: |-
+                      Type of the deployment that you want to create.
+                      The parameter is required if replicationSpecs are set or if Global Deployments are deployed.
+                    enum:
+                    - REPLICASET
+                    - SHARDED
+                    - GEOSHARDED
+                    type: string
+                  customZoneMapping:
+                    items:
+                      properties:
+                        location:
+                          type: string
+                        zone:
+                          type: string
+                      required:
+                      - location
+                      - zone
+                      type: object
+                    type: array
+                  diskSizeGB:
+                    description: |-
+                      Capacity, in gigabytes, of the host's root volume.
+                      Increase this number to add capacity, up to a maximum possible value of 4096 (i.e., 4 TB).
+                      This value must be a positive integer.
+                      The parameter is required if replicationSpecs are configured.
+                    maximum: 4096
+                    minimum: 0
+                    type: integer
+                  encryptionAtRestProvider:
+                    description: Cloud service provider that offers Encryption at
+                      Rest.
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - NONE
+                    type: string
+                  labels:
+                    description: |-
+                      Collection of key-value pairs that tag and categorize the deployment.
+                      Each key and value has a maximum length of 255 characters.
+                    items:
+                      description: LabelSpec contains key-value pairs that tag and
+                        categorize the Cluster/DBUser
+                      properties:
+                        key:
+                          maxLength: 255
+                          type: string
+                        value:
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    type: array
+                  managedNamespaces:
+                    items:
+                      description: ManagedNamespace represents the information about
+                        managed namespace configuration.
+                      properties:
+                        collection:
+                          type: string
+                        customShardKey:
+                          type: string
+                        db:
+                          type: string
+                        isCustomShardKeyHashed:
+                          type: boolean
+                        isShardKeyUnique:
+                          type: boolean
+                        numInitialChunks:
+                          type: integer
+                        presplitHashedZones:
+                          type: boolean
+                      required:
+                      - collection
+                      - db
+                      type: object
+                    type: array
+                  mongoDBMajorVersion:
+                    description: Version of the deployment to deploy.
+                    type: string
+                  mongoDBVersion:
+                    type: string
+                  name:
+                    description: |-
+                      Name of the advanced deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  paused:
+                    description: Flag that indicates whether the deployment should
+                      be paused.
+                    type: boolean
+                  pitEnabled:
+                    description: Flag that indicates the deployment uses continuous
+                      cloud backups.
+                    type: boolean
+                  replicationSpecs:
+                    description: Configuration for deployment regions.
+                    items:
+                      properties:
+                        numShards:
+                          description: |-
+                            Positive integer that specifies the number of shards to deploy in each specified zone.
+                            If you set this value to 1 and clusterType is SHARDED, MongoDB Cloud deploys a single-shard sharded cluster.
+                            Don't create a sharded cluster with a single shard for production environments.
+                            Single-shard sharded clusters don't provide the same benefits as multi-shard configurations
+                          type: integer
+                        regionConfigs:
+                          description: |-
+                            Hardware specifications for nodes set for a given region.
+                            Each regionConfigs object describes the region's priority in elections and the number and type of MongoDB nodes that MongoDB Cloud deploys to the region.
+                            Each regionConfigs object must have either an analyticsSpecs object, electableSpecs object, or readOnlySpecs object.
+                            Tenant clusters only require electableSpecs. Dedicated clusters can specify any of these specifications, but must have at least one electableSpecs object within a replicationSpec.
+                            Every hardware specification must use the same instanceSize.
+                          items:
+                            properties:
+                              analyticsSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              autoScaling:
+                                description: AdvancedAutoScalingSpec configures your
+                                  deployment to automatically scale its storage
+                                properties:
+                                  compute:
+                                    description: Collection of settings that configure
+                                      how a deployment might scale its deployment
+                                      tier and whether the deployment can scale down.
+                                    properties:
+                                      enabled:
+                                        description: Flag that indicates whether deployment
+                                          tier auto-scaling is enabled. The default
+                                          is false.
+                                        type: boolean
+                                      maxInstanceSize:
+                                        description: 'Maximum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M40). Atlas requires this parameter
+                                          if "autoScaling.compute.enabled" : true.'
+                                        type: string
+                                      minInstanceSize:
+                                        description: 'Minimum instance size to which
+                                          your deployment can automatically scale
+                                          (such as M10). Atlas requires this parameter
+                                          if "autoScaling.compute.scaleDownEnabled"
+                                          : true.'
+                                        type: string
+                                      scaleDownEnabled:
+                                        description: 'Flag that indicates whether
+                                          the deployment tier may scale down. Atlas
+                                          requires this parameter if "autoScaling.compute.enabled"
+                                          : true.'
+                                        type: boolean
+                                    type: object
+                                  diskGB:
+                                    description: Flag that indicates whether disk
+                                      auto-scaling is enabled. The default is true.
+                                    properties:
+                                      enabled:
+                                        type: boolean
+                                    type: object
+                                type: object
+                              backingProviderName:
+                                description: |-
+                                  Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                                  This setting only works when "providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                                  Otherwise it should be equal to "providerName" value
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                type: string
+                              electableSpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              priority:
+                                description: |-
+                                  Precedence is given to this region when a primary election occurs.
+                                  If your regionConfigs has only readOnlySpecs, analyticsSpecs, or both, set this value to 0.
+                                  If you have multiple regionConfigs objects (your cluster is multi-region or multi-cloud), they must have priorities in descending order.
+                                  The highest priority is 7
+                                type: integer
+                              providerName:
+                                enum:
+                                - AWS
+                                - GCP
+                                - AZURE
+                                - TENANT
+                                - SERVERLESS
+                                type: string
+                              readOnlySpecs:
+                                properties:
+                                  diskIOPS:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    format: int64
+                                    type: integer
+                                  ebsVolumeType:
+                                    description: |-
+                                      Disk IOPS setting for AWS storage.
+                                      Set only if you selected AWS as your cloud service provider.
+                                    enum:
+                                    - STANDARD
+                                    - PROVISIONED
+                                    type: string
+                                  instanceSize:
+                                    description: |-
+                                      Hardware specification for the instance sizes in this region.
+                                      Each instance size has a default storage and memory capacity.
+                                      The instance size you select applies to all the data-bearing hosts in your instance size
+                                    type: string
+                                  nodeCount:
+                                    description: Number of nodes of the given type
+                                      for MongoDB Cloud to deploy to the region.
+                                    type: integer
+                                type: object
+                              regionName:
+                                description: |-
+                                  Physical location of your MongoDB deployment.
+                                  The region you choose can affect network latency for clients accessing your databases.
+                                type: string
+                            type: object
+                          type: array
+                        zoneName:
+                          description: Human-readable label that identifies the zone
+                            in a Global Cluster.
+                          type: string
+                      type: object
+                    type: array
+                  rootCertType:
+                    type: string
+                  searchIndexes:
+                    description: A list of atlas search indexes configuration for
+                      the current deployment
+                    items:
+                      description: SearchIndex is the CRD to configure part of the
+                        Atlas Search Index
+                      properties:
+                        DBName:
+                          description: Human-readable label that identifies the database
+                            that contains the collection with one or more Atlas Search
+                            indexes
+                          type: string
+                        collectionName:
+                          description: Human-readable label that identifies the collection
+                            that contains one or more Atlas Search indexes
+                          type: string
+                        name:
+                          description: Human-readable label that identifies this index.
+                            Must be unique for a deployment
+                          type: string
+                        search:
+                          description: Atlas search index configuration
+                          properties:
+                            mappings:
+                              description: Index specifications for the collection's
+                                fields
+                              properties:
+                                dynamic:
+                                  description: Flag that indicates whether the index
+                                    uses dynamic or static mappings. Required if mapping.fields
+                                    is omitted.
+                                  type: boolean
+                                fields:
+                                  description: One or more field specifications for
+                                    the Atlas Search index. Required if mapping.dynamic
+                                    is omitted or set to false.
+                                  x-kubernetes-preserve-unknown-fields: true
+                              type: object
+                            searchConfigurationRef:
+                              description: A reference to the AtlasSearchIndexConfig
+                                custom resource
+                              properties:
+                                name:
+                                  description: Name is the name of the Kubernetes
+                                    Resource
+                                  type: string
+                                namespace:
+                                  description: Namespace is the namespace of the Kubernetes
+                                    Resource
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            synonyms:
+                              description: Rule sets that map words to their synonyms
+                                in this index
+                              items:
+                                description: Synonym represents "Synonym" type of
+                                  Atlas Search Index
+                                properties:
+                                  analyzer:
+                                    description: Specific pre-defined method chosen
+                                      to apply to the synonyms to be searched
+                                    enum:
+                                    - lucene.standard
+                                    - lucene.standard
+                                    - lucene.simple
+                                    - lucene.whitespace
+                                    - lucene.keyword
+                                    - lucene.arabic
+                                    - lucene.armenian
+                                    - lucene.basque
+                                    - lucene.bengali
+                                    - lucene.brazilian
+                                    - lucene.bulgarian
+                                    - lucene.catalan
+                                    - lucene.chinese
+                                    - lucene.cjk
+                                    - lucene.czech
+                                    - lucene.danish
+                                    - lucene.dutch
+                                    - lucene.english
+                                    - lucene.finnish
+                                    - lucene.french
+                                    - lucene.galician
+                                    - lucene.german
+                                    - lucene.greek
+                                    - lucene.hindi
+                                    - lucene.hungarian
+                                    - lucene.indonesian
+                                    - lucene.irish
+                                    - lucene.italian
+                                    - lucene.japanese
+                                    - lucene.korean
+                                    - lucene.kuromoji
+                                    - lucene.latvian
+                                    - lucene.lithuanian
+                                    - lucene.morfologik
+                                    - lucene.nori
+                                    - lucene.norwegian
+                                    - lucene.persian
+                                    - lucene.portuguese
+                                    - lucene.romanian
+                                    - lucene.russian
+                                    - lucene.smartcn
+                                    - lucene.sorani
+                                    - lucene.spanish
+                                    - lucene.swedish
+                                    - lucene.thai
+                                    - lucene.turkish
+                                    - lucene.ukrainian
+                                    type: string
+                                  name:
+                                    description: Human-readable label that identifies
+                                      the synonym definition. Each name must be unique
+                                      within the same index definition
+                                    type: string
+                                  source:
+                                    description: Data set that stores the mapping
+                                      one or more words map to one or more synonyms
+                                      of those words
+                                    properties:
+                                      collection:
+                                        description: Human-readable label that identifies
+                                          the MongoDB collection that stores words
+                                          and their applicable synonyms
+                                        type: string
+                                    required:
+                                    - collection
+                                    type: object
+                                required:
+                                - analyzer
+                                - name
+                                - source
+                                type: object
+                              type: array
+                          required:
+                          - mappings
+                          - searchConfigurationRef
+                          type: object
+                        type:
+                          description: Type of the index
+                          enum:
+                          - search
+                          - vectorSearch
+                          type: string
+                        vectorSearch:
+                          description: Atlas vector search index configuration
+                          properties:
+                            fields:
+                              description: Array of JSON objects. See examples https://dochub.mongodb.org/core/avs-vector-type
+                              x-kubernetes-preserve-unknown-fields: true
+                          required:
+                          - fields
+                          type: object
+                      required:
+                      - DBName
+                      - collectionName
+                      - name
+                      - type
+                      type: object
+                    type: array
+                  searchNodes:
+                    description: Settings for Search Nodes for the cluster. Currently,
+                      at most one search node configuration may be defined.
+                    items:
+                      properties:
+                        instanceSize:
+                          description: Hardware specification for the Search Node
+                            instance sizes.
+                          enum:
+                          - S20_HIGHCPU_NVME
+                          - S30_HIGHCPU_NVME
+                          - S40_HIGHCPU_NVME
+                          - S50_HIGHCPU_NVME
+                          - S60_HIGHCPU_NVME
+                          - S70_HIGHCPU_NVME
+                          - S80_HIGHCPU_NVME
+                          - S30_LOWCPU_NVME
+                          - S40_LOWCPU_NVME
+                          - S50_LOWCPU_NVME
+                          - S60_LOWCPU_NVME
+                          - S80_LOWCPU_NVME
+                          - S90_LOWCPU_NVME
+                          - S100_LOWCPU_NVME
+                          - S110_LOWCPU_NVME
+                          type: string
+                        nodeCount:
+                          description: Number of Search Nodes in the cluster.
+                          maximum: 32
+                          minimum: 2
+                          type: integer
+                      type: object
+                    maxItems: 1
+                    type: array
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                  versionReleaseSystem:
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              flexSpec:
+                description: Configuration for the Flex cluster API. https://www.mongodb.com/docs/atlas/reference/api-resources-spec/v2/#tag/Flex-Clusters
+                properties:
+                  name:
+                    description: Human-readable label that identifies the instance.
+                    type: string
+                  providerSettings:
+                    description: Group of cloud provider settings that configure the
+                      provisioned MongoDB flex cluster.
+                    properties:
+                      backingProviderName:
+                        description: Cloud service provider on which MongoDB Atlas
+                          provisions the flex cluster.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Backing Provider cannot be modified after cluster
+                            creation
+                          rule: self == oldSelf
+                      regionName:
+                        description: |-
+                          Human-readable label that identifies the geographic location of your MongoDB flex cluster.
+                          The region you choose can affect network latency for clients accessing your databases.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: Region Name cannot be modified after cluster creation
+                          rule: self == oldSelf
+                    required:
+                    - backingProviderName
+                    - regionName
+                    type: object
+                  tags:
+                    description: List that contains key-value pairs between 1 to 255
+                      characters in length for tagging and categorizing the instance.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: |-
+                      Flag that indicates whether termination protection is enabled on the cluster.
+                      If set to true, MongoDB Cloud won't delete the cluster. If set to false, MongoDB Cloud will delete the cluster.
+                    type: boolean
+                required:
+                - name
+                - providerSettings
+                type: object
+              processArgs:
+                description: ProcessArgs allows to modify Advanced Configuration Options
+                properties:
+                  defaultReadConcern:
+                    type: string
+                  defaultWriteConcern:
+                    type: string
+                  failIndexKeyTooLong:
+                    type: boolean
+                  javascriptEnabled:
+                    type: boolean
+                  minimumEnabledTlsProtocol:
+                    type: string
+                  noTableScan:
+                    type: boolean
+                  oplogMinRetentionHours:
+                    type: string
+                  oplogSizeMB:
+                    format: int64
+                    type: integer
+                  sampleRefreshIntervalBIConnector:
+                    format: int64
+                    type: integer
+                  sampleSizeBIConnector:
+                    format: int64
+                    type: integer
+                type: object
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              serverlessSpec:
+                description: |-
+                  Configuration for the serverless deployment API. https://www.mongodb.com/docs/atlas/reference/api/serverless-instances/
+                  DEPRECATED FIELD: Serverless instances are deprecated. See https://dochub.mongodb.org/core/atlas-flex-migration for details.
+                properties:
+                  backupOptions:
+                    description: Serverless Backup Options
+                    properties:
+                      serverlessContinuousBackupEnabled:
+                        default: true
+                        description: ServerlessContinuousBackupEnabled
+                        type: boolean
+                    type: object
+                  name:
+                    description: |-
+                      Name of the serverless deployment as it appears in Atlas.
+                      After Atlas creates the deployment, you can't change its name.
+                      Can only contain ASCII letters, numbers, and hyphens.
+                    pattern: ^[a-zA-Z0-9][a-zA-Z0-9-]*$
+                    type: string
+                  privateEndpoints:
+                    items:
+                      properties:
+                        cloudProviderEndpointID:
+                          description: CloudProviderEndpointID is the identifier of
+                            the cloud provider endpoint.
+                          type: string
+                        name:
+                          description: Name is the name of the Serverless PrivateLink
+                            Service. Should be unique.
+                          type: string
+                        privateEndpointIpAddress:
+                          description: PrivateEndpointIPAddress is the IPv4 address
+                            of the private endpoint in your Azure VNet that someone
+                            added to this private endpoint service.
+                          type: string
+                      type: object
+                    type: array
+                  providerSettings:
+                    description: Configuration for the provisioned hosts on which
+                      MongoDB runs. The available options are specific to the cloud
+                      service provider.
+                    properties:
+                      autoScaling:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Range of instance sizes to which your deployment
+                          can scale.
+                        properties:
+                          autoIndexingEnabled:
+                            description: |-
+                              Deprecated: This flag is not supported anymore.
+                              Flag that indicates whether autopilot mode for Performance Advisor is enabled.
+                              The default is false.
+                            type: boolean
+                          compute:
+                            description: Collection of settings that configure how
+                              a deployment might scale its deployment tier and whether
+                              the deployment can scale down.
+                            properties:
+                              enabled:
+                                description: Flag that indicates whether deployment
+                                  tier auto-scaling is enabled. The default is false.
+                                type: boolean
+                              maxInstanceSize:
+                                description: 'Maximum instance size to which your
+                                  deployment can automatically scale (such as M40).
+                                  Atlas requires this parameter if "autoScaling.compute.enabled"
+                                  : true.'
+                                type: string
+                              minInstanceSize:
+                                description: 'Minimum instance size to which your
+                                  deployment can automatically scale (such as M10).
+                                  Atlas requires this parameter if "autoScaling.compute.scaleDownEnabled"
+                                  : true.'
+                                type: string
+                              scaleDownEnabled:
+                                description: 'Flag that indicates whether the deployment
+                                  tier may scale down. Atlas requires this parameter
+                                  if "autoScaling.compute.enabled" : true.'
+                                type: boolean
+                            type: object
+                          diskGBEnabled:
+                            description: Flag that indicates whether disk auto-scaling
+                              is enabled. The default is true.
+                            type: boolean
+                        type: object
+                      backingProviderName:
+                        description: |-
+                          Cloud service provider on which the host for a multi-tenant deployment is provisioned.
+                          This setting only works when "providerSetting.providerName" : "TENANT" and "providerSetting.instanceSizeName" : M2 or M5.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        type: string
+                      diskIOPS:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        format: int64
+                        type: integer
+                      diskTypeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Type of disk if you selected Azure as your
+                          cloud service provider.
+                        type: string
+                      encryptEBSVolume:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Flag that indicates whether the Amazon
+                          EBS encryption feature encrypts the host's root volume for
+                          both data at rest within the volume and for data moving
+                          between the volume and the deployment.
+                        type: boolean
+                      instanceSizeName:
+                        description: DEPRECATED FIELD. The value of this field doesn't
+                          take any effect. Atlas provides different deployment tiers,
+                          each with a default storage capacity and RAM size. The deployment
+                          you select is used for all the data-bearing hosts in your
+                          deployment tier.
+                        type: string
+                      providerName:
+                        description: Cloud service provider on which Atlas provisions
+                          the hosts.
+                        enum:
+                        - AWS
+                        - GCP
+                        - AZURE
+                        - TENANT
+                        - SERVERLESS
+                        type: string
+                      regionName:
+                        description: |-
+                          Physical location of your MongoDB deployment.
+                          The region you choose can affect network latency for clients accessing your databases.
+                        type: string
+                      volumeType:
+                        description: |-
+                          DEPRECATED FIELD. The value of this field doesn't take any effect. Disk IOPS setting for AWS storage.
+                          Set only if you selected AWS as your cloud service provider.
+                        enum:
+                        - STANDARD
+                        - PROVISIONED
+                        type: string
+                    required:
+                    - providerName
+                    type: object
+                  tags:
+                    description: Key-value pairs for resource tagging.
+                    items:
+                      description: TagSpec holds a key-value pair for resource tagging
+                        on this deployment.
+                      properties:
+                        key:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9 @_.+`;`-]*$
+                          type: string
+                        value:
+                          maxLength: 255
+                          minLength: 1
+                          pattern: ^[a-zA-Z0-9][a-zA-Z0-9@_.+`;`-]*$
+                          type: string
+                      required:
+                      - key
+                      - value
+                      type: object
+                    maxItems: 50
+                    type: array
+                  terminationProtectionEnabled:
+                    default: false
+                    description: Flag that indicates whether termination protection
+                      is enabled on the cluster. If set to true, MongoDB Cloud won't
+                      delete the cluster. If set to false, MongoDB Cloud will delete
+                      the cluster.
+                    type: boolean
+                required:
+                - name
+                - providerSettings
+                type: object
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasDeploymentStatus defines the observed state of AtlasDeployment.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connectionStrings:
+                description: ConnectionStrings is a set of connection strings that
+                  your applications use to connect to this cluster.
+                properties:
+                  private:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                    type: string
+                  privateEndpoint:
+                    description: |-
+                      Private endpoint connection strings.
+                      Each object describes the connection strings you can use to connect to this cluster through a private endpoint.
+                      Atlas returns this parameter only if you deployed a private endpoint to all regions to which you deployed this cluster's nodes.
+                    items:
+                      description: |-
+                        PrivateEndpoint connection strings. Each object describes the connection strings
+                        you can use to connect to this cluster through a private endpoint.
+                        Atlas returns this parameter only if you deployed a private endpoint to all regions
+                        to which you deployed this cluster's nodes.
+                      properties:
+                        connectionString:
+                          description: Private-endpoint-aware mongodb:// connection
+                            string for this private endpoint.
+                          type: string
+                        endpoints:
+                          description: Private endpoint through which you connect
+                            to Atlas when you use connectionStrings.privateEndpoint[n].connectionString
+                            or connectionStrings.privateEndpoint[n].srvConnectionString.
+                          items:
+                            description: Endpoint through which you connect to Atlas
+                            properties:
+                              endpointId:
+                                description: Unique identifier of the private endpoint.
+                                type: string
+                              ip:
+                                description: Private IP address of the private endpoint
+                                  network interface you created in your Azure VNet.
+                                type: string
+                              providerName:
+                                description: Cloud provider to which you deployed
+                                  the private endpoint. Atlas returns AWS or AZURE.
+                                type: string
+                              region:
+                                description: Region to which you deployed the private
+                                  endpoint.
+                                type: string
+                            type: object
+                          type: array
+                        srvConnectionString:
+                          description: Private-endpoint-aware mongodb+srv:// connection
+                            string for this private endpoint.
+                          type: string
+                        srvShardOptimizedConnectionString:
+                          type: string
+                        type:
+                          description: |-
+                            Type of MongoDB process that you connect to with the connection strings
+
+                            Atlas returns:
+
+                            • MONGOD for replica sets, or
+
+                            • MONGOS for sharded clusters
+                          type: string
+                      type: object
+                    type: array
+                  privateSrv:
+                    description: |-
+                      Network-peering-endpoint-aware mongodb+srv:// connection strings for each interface VPC endpoint you configured to connect to this cluster.
+                      Atlas returns this parameter only if you created a network peering connection to this cluster.
+                      Use this URI format if your driver supports it. If it doesn't, use connectionStrings.private.
+                    type: string
+                  standard:
+                    description: Public mongodb:// connection string for this cluster.
+                    type: string
+                  standardSrv:
+                    description: Public mongodb+srv:// connection string for this
+                      cluster.
+                    type: string
+                type: object
+              customZoneMapping:
+                properties:
+                  customZoneMapping:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  zoneMappingErrMessage:
+                    type: string
+                  zoneMappingState:
+                    type: string
+                type: object
+              managedNamespaces:
+                items:
+                  properties:
+                    collection:
+                      type: string
+                    customShardKey:
+                      type: string
+                    db:
+                      type: string
+                    errMessage:
+                      type: string
+                    isCustomShardKeyHashed:
+                      type: boolean
+                    isShardKeyUnique:
+                      type: boolean
+                    numInitialChunks:
+                      type: integer
+                    presplitHashedZones:
+                      type: boolean
+                    status:
+                      type: string
+                  required:
+                  - collection
+                  - db
+                  type: object
+                type: array
+              mongoDBVersion:
+                description: MongoDBVersion is the version of MongoDB the cluster
+                  runs, in <major version>.<minor version> format.
+                type: string
+              mongoURIUpdated:
+                description: |-
+                  MongoURIUpdated is a timestamp in ISO 8601 date and time format in UTC when the connection string was last updated.
+                  The connection string changes if you update any of the other values.
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              replicaSets:
+                items:
+                  properties:
+                    id:
+                      type: string
+                    zoneName:
+                      type: string
+                  required:
+                  - id
+                  type: object
+                type: array
+              searchIndexes:
+                description: SearchIndexes contains a list of search indexes statuses
+                  configured for a project
+                items:
+                  properties:
+                    ID:
+                      type: string
+                    message:
+                      type: string
+                    name:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - ID
+                  - message
+                  - name
+                  - status
+                  type: object
+                type: array
+              serverlessPrivateEndpoints:
+                items:
+                  properties:
+                    _id:
+                      description: ID is the identifier of the Serverless PrivateLink
+                        Service.
+                      type: string
+                    cloudProviderEndpointId:
+                      description: CloudProviderEndpointID is the identifier of the
+                        cloud provider endpoint.
+                      type: string
+                    endpointServiceName:
+                      description: EndpointServiceName is the name of the PrivateLink
+                        endpoint service in AWS. Returns null while the endpoint service
+                        is being created.
+                      type: string
+                    errorMessage:
+                      description: ErrorMessage is the error message if the Serverless
+                        PrivateLink Service failed to create or connect.
+                      type: string
+                    name:
+                      description: Name is the name of the Serverless PrivateLink
+                        Service. Should be unique.
+                      type: string
+                    privateEndpointIpAddress:
+                      description: PrivateEndpointIPAddress is the IPv4 address of
+                        the private endpoint in your Azure VNet that someone added
+                        to this private endpoint service.
+                      type: string
+                    privateLinkServiceResourceId:
+                      description: PrivateLinkServiceResourceID is the root-relative
+                        path that identifies the Azure Private Link Service that MongoDB
+                        Cloud manages. MongoDB Cloud returns null while it creates
+                        the endpoint service.
+                      type: string
+                    providerName:
+                      description: ProviderName is human-readable label that identifies
+                        the cloud provider. Values include AWS or AZURE.
+                      type: string
+                    status:
+                      description: Status of the AWS Serverless PrivateLink connection.
+                      type: string
+                  type: object
+                type: array
+              stateName:
+                description: |-
+                  StateName is the current state of the cluster.
+                  The possible states are: IDLE, CREATING, UPDATING, DELETING, DELETED, REPAIRING
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasfederatedauths.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasfederatedauths.yaml
@@ -1,0 +1,201 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasfederatedauths.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasFederatedAuth
+    listKind: AtlasFederatedAuthList
+    plural: atlasfederatedauths
+    shortNames:
+    - afa
+    singular: atlasfederatedauth
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasFederatedAuth is the Schema for the Atlasfederatedauth API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              connectionSecretRef:
+                description: |-
+                  Connection secret with API credentials for configuring the federation.
+                  These credentials must have OrganizationOwner permissions.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              dataAccessIdentityProviders:
+                description: |-
+                  The collection of unique ids representing the identity providers that can be used for data access in this organization.
+                  Currently connected data access identity providers missing from the this field will be disconnected.
+                items:
+                  type: string
+                type: array
+              domainAllowList:
+                description: Approved domains that restrict users who can join the
+                  organization based on their email address.
+                items:
+                  type: string
+                type: array
+              domainRestrictionEnabled:
+                default: false
+                description: |-
+                  Prevent users in the federation from accessing organizations outside of the federation, and creating new organizations.
+                  This option applies to the entire federation.
+                  See more information at https://www.mongodb.com/docs/atlas/security/federation-advanced-options/#restrict-user-membership-to-the-federation
+                type: boolean
+              enabled:
+                default: false
+                type: boolean
+              postAuthRoleGrants:
+                description: Atlas roles that are granted to a user in this organization
+                  after authenticating.
+                items:
+                  type: string
+                type: array
+              roleMappings:
+                description: Map IDP groups to Atlas roles.
+                items:
+                  description: RoleMapping maps an external group from an identity
+                    provider to roles within Atlas.
+                  properties:
+                    externalGroupName:
+                      description: ExternalGroupName is the name of the IDP group
+                        to which this mapping applies.
+                      maxLength: 200
+                      minLength: 1
+                      type: string
+                    roleAssignments:
+                      description: RoleAssignments define the roles within projects
+                        that should be given to members of the group.
+                      items:
+                        properties:
+                          projectName:
+                            description: The Atlas project in the same org in which
+                              the role should be given.
+                            type: string
+                          role:
+                            description: The role in Atlas that should be given to
+                              group members.
+                            enum:
+                            - ORG_MEMBER
+                            - ORG_READ_ONLY
+                            - ORG_BILLING_ADMIN
+                            - ORG_GROUP_CREATOR
+                            - ORG_OWNER
+                            - ORG_BILLING_READ_ONLY
+                            - ORG_TEAM_MEMBERS_ADMIN
+                            - GROUP_AUTOMATION_ADMIN
+                            - GROUP_BACKUP_ADMIN
+                            - GROUP_MONITORING_ADMIN
+                            - GROUP_OWNER
+                            - GROUP_READ_ONLY
+                            - GROUP_USER_ADMIN
+                            - GROUP_BILLING_ADMIN
+                            - GROUP_DATA_ACCESS_ADMIN
+                            - GROUP_DATA_ACCESS_READ_ONLY
+                            - GROUP_DATA_ACCESS_READ_WRITE
+                            - GROUP_CHARTS_ADMIN
+                            - GROUP_CLUSTER_MANAGER
+                            - GROUP_SEARCH_INDEX_EDITOR
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              ssoDebugEnabled:
+                default: false
+                type: boolean
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasipaccesslists.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasipaccesslists.yaml
@@ -1,0 +1,202 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasipaccesslists.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasIPAccessList
+    listKind: AtlasIPAccessListList
+    plural: atlasipaccesslists
+    shortNames:
+    - aip
+    singular: atlasipaccesslist
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasIPAccessList is the Schema for the atlasipaccesslists API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasIPAccessListSpec defines the desired state of AtlasIPAccessList.
+            properties:
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              entries:
+                description: Entries is the list of IP Access to be managed
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Date and time after which Atlas deletes the temporary
+                        access list entry.
+                      format: date-time
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                  - message: Only one of ipAddress, cidrBlock, or awsSecurityGroup
+                      may be set.
+                    rule: '!(has(self.ipAddress) && (has(self.cidrBlock) || has(self.awsSecurityGroup)))
+                      && !(has(self.cidrBlock) && has(self.awsSecurityGroup))'
+                minItems: 1
+                type: array
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - entries
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasIPAccessListStatus is the most recent observed status
+              of the AtlasIPAccessList cluster. Read-only.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              entries:
+                description: Status is the state of the ip access list
+                items:
+                  properties:
+                    entry:
+                      description: Entry is the ip access Atlas is managing
+                      type: string
+                    status:
+                      description: Status is the correspondent state of the entry
+                      type: string
+                  required:
+                  - entry
+                  - status
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasprivateendpoints.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasprivateendpoints.yaml
@@ -1,0 +1,331 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasprivateendpoints.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasPrivateEndpoint
+    listKind: AtlasPrivateEndpointList
+    plural: atlasprivateendpoints
+    shortNames:
+    - ape
+    singular: atlasprivateendpoint
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.provider
+      name: Provider
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          The AtlasPrivateEndpoint custom resource definition (CRD) defines a desired [Private Endpoint](https://www.mongodb.com/docs/atlas/security-private-endpoint/#std-label-private-endpoint-overview) configuration for an Atlas project.
+          It allows a private connection between your cloud provider and Atlas that doesn't send information through a public network.
+
+          You can use private endpoints to create a unidirectional connection to Atlas clusters from your virtual network.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasPrivateEndpointSpec is the specification of the desired
+              configuration of a project private endpoint
+            properties:
+              awsConfiguration:
+                description: AWSConfiguration is the specific AWS settings for the
+                  private endpoint
+                items:
+                  description: AWSPrivateEndpointConfiguration holds the AWS configuration
+                    done on customer network
+                  properties:
+                    id:
+                      description: ID that identifies the private endpoint's network
+                        interface that someone added to this private endpoint service.
+                      type: string
+                  required:
+                  - id
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
+              azureConfiguration:
+                description: AzureConfiguration is the specific Azure settings for
+                  the private endpoint
+                items:
+                  description: AzurePrivateEndpointConfiguration holds the Azure configuration
+                    done on customer network
+                  properties:
+                    id:
+                      description: ID that identifies the private endpoint's network
+                        interface that someone added to this private endpoint service.
+                      type: string
+                    ipAddress:
+                      description: IP address of the private endpoint in your Azure
+                        VNet that someone added to this private endpoint service.
+                      type: string
+                  required:
+                  - id
+                  - ipAddress
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
+              connectionSecret:
+                description: Name of the secret containing Atlas API private and public
+                  keys
+                properties:
+                  name:
+                    description: |-
+                      Name of the resource being referred to
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                required:
+                - name
+                type: object
+              externalProjectRef:
+                description: |-
+                  "externalProjectRef" holds the parent Atlas project ID.
+                  Mutually exclusive with the "projectRef" field
+                properties:
+                  id:
+                    description: ID is the Atlas project ID
+                    type: string
+                required:
+                - id
+                type: object
+              gcpConfiguration:
+                description: GCPConfiguration is the specific Google Cloud settings
+                  for the private endpoint
+                items:
+                  description: GCPPrivateEndpointConfiguration holds the GCP configuration
+                    done on customer network
+                  properties:
+                    endpoints:
+                      description: Endpoints is the list of individual private endpoints
+                        that comprise this endpoint group.
+                      items:
+                        description: GCPPrivateEndpoint holds the GCP forwarding rules
+                          configured on customer network
+                        properties:
+                          ipAddress:
+                            description: IP address to which this Google Cloud consumer
+                              forwarding rule resolves.
+                            type: string
+                          name:
+                            description: Name that identifies the Google Cloud consumer
+                              forwarding rule that you created.
+                            type: string
+                        required:
+                        - ipAddress
+                        - name
+                        type: object
+                      type: array
+                    groupName:
+                      description: GroupName is the label that identifies a set of
+                        endpoints.
+                      type: string
+                    projectId:
+                      description: ProjectID that identifies the Google Cloud project
+                        in which you created the endpoints.
+                      type: string
+                  required:
+                  - endpoints
+                  - groupName
+                  - projectId
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - groupName
+                x-kubernetes-list-type: map
+              projectRef:
+                description: |-
+                  "projectRef" is a reference to the parent AtlasProject resource.
+                  Mutually exclusive with the "externalProjectRef" field
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              provider:
+                description: Name of the cloud service provider for which you want
+                  to create the private endpoint service.
+                enum:
+                - AWS
+                - GCP
+                - AZURE
+                type: string
+              region:
+                description: Region of the chosen cloud provider in which you want
+                  to create the private endpoint service.
+                type: string
+            required:
+            - provider
+            - region
+            type: object
+            x-kubernetes-validations:
+            - message: must define only one project reference through externalProjectRef
+                or projectRef
+              rule: (has(self.externalProjectRef) && !has(self.projectRef)) || (!has(self.externalProjectRef)
+                && has(self.projectRef))
+            - message: must define a local connection secret when referencing an external
+                project
+              rule: (has(self.externalProjectRef) && has(self.connectionSecret)) ||
+                !has(self.externalProjectRef)
+          status:
+            description: AtlasPrivateEndpointStatus is the most recent observed status
+              of the AtlasPrivateEndpoint cluster. Read-only.
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpoints:
+                description: Endpoints are the status of the endpoints connected to
+                  the service
+                items:
+                  description: EndpointInterfaceStatus is the most recent observed
+                    status the interfaces attached to the configured service. Read-only.
+                  properties:
+                    ID:
+                      description: ID is the external identifier set on the specification
+                        to configure the interface
+                      type: string
+                    InterfaceStatus:
+                      description: InterfaceStatus is the state of the private endpoint
+                        interface
+                      type: string
+                    connectionName:
+                      description: ConnectionName is the label that Atlas generates
+                        that identifies the Azure private endpoint connection
+                      type: string
+                    error:
+                      description: Error is the description of the failure occurred
+                        when configuring the private endpoint
+                      type: string
+                    gcpForwardingRules:
+                      description: GCPForwardingRules is the status of the customer
+                        GCP private endpoint(forwarding rules)
+                      items:
+                        description: GCPForwardingRule is the most recent observed
+                          status the GCP forwarding rules configured for an interface.
+                          Read-only.
+                        properties:
+                          name:
+                            type: string
+                          status:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              error:
+                description: Error is the description of the failure occurred when
+                  configuring the private endpoint
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              resourceId:
+                description: ResourceID is the root-relative path that identifies
+                  of the Atlas Azure Private Link Service
+                type: string
+              serviceAttachmentNames:
+                description: ServiceAttachmentNames is the list of URLs that identifies
+                  endpoints that Atlas can use to access one service across the private
+                  connection
+                items:
+                  type: string
+                type: array
+              serviceId:
+                description: ServiceID is the unique identifier of the private endpoint
+                  service in Atlas
+                type: string
+              serviceName:
+                description: ServiceName is the unique identifier of the Amazon Web
+                  Services (AWS) PrivateLink endpoint service or Azure Private Link
+                  Service managed by Atlas
+                type: string
+              serviceStatus:
+                description: ServiceStatus is the state of the private endpoint service
+                type: string
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasprojects.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasprojects.yaml
@@ -1,0 +1,1558 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasprojects.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasProject
+    listKind: AtlasProjectList
+    plural: atlasprojects
+    shortNames:
+    - ap
+    singular: atlasproject
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .spec.name
+      name: Atlas Name
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasProject is the Schema for the atlasprojects API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AtlasProjectSpec defines the desired state of Project in
+              Atlas
+            properties:
+              alertConfigurationSyncEnabled:
+                description: |-
+                  AlertConfigurationSyncEnabled is a flag that enables/disables Alert Configurations sync for the current Project.
+                  If true - project alert configurations will be synced according to AlertConfigurations.
+                  If not - alert configurations will not be modified by the operator. They can be managed through API, cli, UI.
+                type: boolean
+              alertConfigurations:
+                description: AlertConfiguration is a list of Alert Configurations
+                  configured for the current Project.
+                items:
+                  properties:
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiTokenRef:
+                            description: Secret containing a Slack API token or Bot
+                              token. Populated for the SLACK notifications type. If
+                              the token later becomes invalid, Atlas sends an email
+                              to the project owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogAPIKeyRef:
+                            description: Secret containing a Datadog API Key. Found
+                              in the Datadog dashboard. Populated for the DATADOG
+                              notifications type.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow name in lower-case letters.
+                            type: string
+                          flowdockApiTokenRef:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKeyRef:
+                            description: OpsGenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKeyRef:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsSecretRef:
+                            description: Secret containing a VictorOps API key and
+                              Routing key. Populated for the VICTOR_OPS notifications
+                              type. If the key later becomes invalid, Atlas sends
+                              an email to the project owner and eventually removes
+                              the key.
+                            properties:
+                              name:
+                                description: Name is the name of the Kubernetes Resource
+                                type: string
+                              namespace:
+                                description: Namespace is the namespace of the Kubernetes
+                                  Resource
+                                type: string
+                            required:
+                            - name
+                            type: object
+                        type: object
+                      type: array
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              auditing:
+                description: Auditing represents MongoDB Maintenance Windows
+                properties:
+                  auditAuthorizationSuccess:
+                    description: 'Indicates whether the auditing system captures successful
+                      authentication attempts for audit filters using the "atype"
+                      : "authCheck" auditing event. For more information, see auditAuthorizationSuccess'
+                    type: boolean
+                  auditFilter:
+                    description: JSON-formatted audit filter used by the project
+                    type: string
+                  enabled:
+                    description: Denotes whether or not the project associated with
+                      the {GROUP-ID} has database auditing enabled.
+                    type: boolean
+                type: object
+              backupCompliancePolicyRef:
+                description: BackupCompliancePolicyRef is a reference to the backup
+                  compliance CR.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              cloudProviderAccessRoles:
+                description: |-
+                  CloudProviderAccessRoles is a list of Cloud Provider Access Roles configured for the current Project.
+                  Deprecated: This configuration was deprecated in favor of CloudProviderIntegrations
+                items:
+                  description: |-
+                    CloudProviderAccessRole define an integration to a cloud provider
+                    Deprecated: This type is deprecated in favor of CloudProviderIntegration
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations is a list of Cloud Provider
+                  Integration configured for the current Project.
+                items:
+                  description: CloudProviderIntegration define an integration to a
+                    cloud provider
+                  properties:
+                    iamAssumedRoleArn:
+                      description: IamAssumedRoleArn is the ARN of the IAM role that
+                        is assumed by the Atlas cluster.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the cloud provider.
+                        Currently only AWS is supported.
+                      type: string
+                  required:
+                  - providerName
+                  type: object
+                type: array
+              connectionSecretRef:
+                description: |-
+                  ConnectionSecret is the name of the Kubernetes Secret which contains the information about the way to connect to
+                  Atlas (organization ID, API keys). The default Operator connection configuration will be used if not provided.
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+              customRoles:
+                description: The customRoles lets you create, and change custom roles
+                  in your cluster. Use custom roles to specify custom sets of actions
+                  that the Atlas built-in roles can't describe.
+                items:
+                  properties:
+                    actions:
+                      description: List of the individual privilege actions that the
+                        role grants.
+                      items:
+                        properties:
+                          name:
+                            description: Human-readable label that identifies the
+                              privilege action.
+                            type: string
+                          resources:
+                            description: List of resources on which you grant the
+                              action.
+                            items:
+                              properties:
+                                cluster:
+                                  description: Flag that indicates whether to grant
+                                    the action on the cluster resource. If true, MongoDB
+                                    Cloud ignores Database and Collection parameters.
+                                  type: boolean
+                                collection:
+                                  description: Human-readable label that identifies
+                                    the collection on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                                database:
+                                  description: Human-readable label that identifies
+                                    the database on which you grant the action to
+                                    one MongoDB user.
+                                  type: string
+                              type: object
+                            type: array
+                        required:
+                        - name
+                        - resources
+                        type: object
+                      type: array
+                    inheritedRoles:
+                      description: List of the built-in roles that this custom role
+                        inherits.
+                      items:
+                        properties:
+                          database:
+                            description: Human-readable label that identifies the
+                              database on which someone grants the action to one MongoDB
+                              user.
+                            type: string
+                          name:
+                            description: Human-readable label that identifies the
+                              role inherited.
+                            type: string
+                        required:
+                        - database
+                        - name
+                        type: object
+                      type: array
+                    name:
+                      description: Human-readable label that identifies the role.
+                        This name must be unique for this custom role in this project.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              encryptionAtRest:
+                description: EncryptionAtRest allows to set encryption for AWS, Azure
+                  and GCP providers
+                properties:
+                  awsKms:
+                    description: AwsKms specifies AWS KMS configuration details and
+                      whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      region:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the AccessKeyID,
+                          SecretAccessKey, CustomerMasterKeyID and RoleID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      valid:
+                        type: boolean
+                    type: object
+                  azureKeyVault:
+                    description: AzureKeyVault specifies Azure Key Vault configuration
+                      details and whether Encryption at Rest is enabled for an Atlas
+                      project.
+                    properties:
+                      azureEnvironment:
+                        type: string
+                      clientID:
+                        type: string
+                      enabled:
+                        type: boolean
+                      resourceGroupName:
+                        type: string
+                      secretRef:
+                        description: A reference to as Secret containing the SubscriptionID,
+                          KeyVaultName, KeyIdentifier, Secret fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      tenantID:
+                        type: string
+                    type: object
+                  googleCloudKms:
+                    description: GoogleCloudKms specifies GCP KMS configuration details
+                      and whether Encryption at Rest is enabled for an Atlas project.
+                    properties:
+                      enabled:
+                        type: boolean
+                      secretRef:
+                        description: A reference to as Secret containing the ServiceAccountKey,
+                          KeyVersionResourceID fields
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    type: object
+                type: object
+              integrations:
+                description: Integrations is a list of MongoDB Atlas integrations
+                  for the project
+                items:
+                  properties:
+                    accountId:
+                      type: string
+                    apiKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    apiTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    channelName:
+                      type: string
+                    enabled:
+                      type: boolean
+                    flowName:
+                      type: string
+                    licenseKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    microsoftTeamsWebhookUrl:
+                      type: string
+                    name:
+                      type: string
+                    orgName:
+                      type: string
+                    passwordRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    readTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    region:
+                      type: string
+                    routingKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    scheme:
+                      type: string
+                    secretRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    serviceDiscovery:
+                      type: string
+                    serviceKeyRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    teamName:
+                      type: string
+                    type:
+                      description: Third Party Integration type such as Slack, New
+                        Relic, etc
+                      enum:
+                      - PAGER_DUTY
+                      - SLACK
+                      - DATADOG
+                      - NEW_RELIC
+                      - OPS_GENIE
+                      - VICTOR_OPS
+                      - FLOWDOCK
+                      - WEBHOOK
+                      - MICROSOFT_TEAMS
+                      - PROMETHEUS
+                      type: string
+                    url:
+                      type: string
+                    username:
+                      type: string
+                    writeTokenRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              maintenanceWindow:
+                description: |-
+                  MaintenanceWindow allows to specify a preferred time in the week to run maintenance operations. See more
+                  information at https://www.mongodb.com/docs/atlas/reference/api/maintenance-windows/
+                properties:
+                  autoDefer:
+                    description: Flag indicating whether any scheduled project maintenance
+                      should be deferred automatically for one week.
+                    type: boolean
+                  dayOfWeek:
+                    description: |-
+                      Day of the week when you would like the maintenance window to start as a 1-based integer.
+                      Sunday 1, Monday 2, Tuesday 3, Wednesday 4, Thursday 5, Friday 6, Saturday 7
+                    maximum: 7
+                    minimum: 1
+                    type: integer
+                  defer:
+                    description: |-
+                      Flag indicating whether the next scheduled project maintenance should be deferred for one week.
+                      Cannot be specified if startASAP is true
+                    type: boolean
+                  hourOfDay:
+                    description: |-
+                      Hour of the day when you would like the maintenance window to start.
+                      This parameter uses the 24-hour clock, where midnight is 0, noon is 12.
+                    maximum: 23
+                    minimum: 0
+                    type: integer
+                  startASAP:
+                    description: |-
+                      Flag indicating whether project maintenance has been directed to start immediately.
+                      Cannot be specified if defer is true
+                    type: boolean
+                type: object
+              name:
+                description: Name is the name of the Project that is created in Atlas
+                  by the Operator if it doesn't exist yet.
+                type: string
+              networkPeers:
+                description: NetworkPeers is a list of Network Peers configured for
+                  the current Project.
+                items:
+                  properties:
+                    accepterRegionName:
+                      description: AccepterRegionName is the provider region name
+                        of user's vpc.
+                      type: string
+                    atlasCidrBlock:
+                      description: Atlas CIDR. It needs to be set if ContainerID is
+                        not set.
+                      type: string
+                    awsAccountId:
+                      description: AccountID of the user's vpc.
+                      type: string
+                    azureDirectoryId:
+                      description: AzureDirectoryID is the unique identifier for an
+                        Azure AD directory.
+                      type: string
+                    azureSubscriptionId:
+                      description: AzureSubscriptionID is the unique identifier of
+                        the Azure subscription in which the VNet resides.
+                      type: string
+                    containerId:
+                      description: ID of the network peer container. If not set, operator
+                        will create a new container with ContainerRegion and AtlasCIDRBlock
+                        input.
+                      type: string
+                    containerRegion:
+                      description: ContainerRegion is the provider region name of
+                        Atlas network peer container. If not set, AccepterRegionName
+                        is used.
+                      type: string
+                    gcpProjectId:
+                      description: User GCP Project ID. Its applicable only for GCP.
+                      type: string
+                    networkName:
+                      description: GCP Network Peer Name. Its applicable only for
+                        GCP.
+                      type: string
+                    providerName:
+                      description: ProviderName is the name of the provider. If not
+                        set, it will be set to "AWS".
+                      type: string
+                    resourceGroupName:
+                      description: ResourceGroupName is the name of your Azure resource
+                        group.
+                      type: string
+                    routeTableCidrBlock:
+                      description: User VPC CIDR.
+                      type: string
+                    vnetName:
+                      description: VNetName is name of your Azure VNet. Its applicable
+                        only for Azure.
+                      type: string
+                    vpcId:
+                      description: AWS VPC ID.
+                      type: string
+                  type: object
+                type: array
+              privateEndpoints:
+                description: PrivateEndpoints is a list of Private Endpoints configured
+                  for the current Project.
+                items:
+                  properties:
+                    endpointGroupName:
+                      description: Unique identifier of the endpoint group. The endpoint
+                        group encompasses all of the endpoints that you created in
+                        Google Cloud.
+                      type: string
+                    endpoints:
+                      description: Collection of individual private endpoints that
+                        comprise your endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            description: Forwarding rule that corresponds to the endpoint
+                              you created in Google Cloud.
+                            type: string
+                          ipAddress:
+                            description: Private IP address of the endpoint you created
+                              in Google Cloud.
+                            type: string
+                        type: object
+                      type: array
+                    gcpProjectId:
+                      description: Unique identifier of the Google Cloud project in
+                        which you created your endpoints.
+                      type: string
+                    id:
+                      description: Unique identifier of the private endpoint you created
+                        in your AWS VPC or Azure Vnet.
+                      type: string
+                    ip:
+                      description: Private IP address of the private endpoint network
+                        interface you created in your Azure VNet.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      enum:
+                      - AWS
+                      - GCP
+                      - AZURE
+                      - TENANT
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              projectIpAccessList:
+                description: |-
+                  ProjectIPAccessList allows to enable the IP Access List for the Project. See more information at
+                  https://docs.atlas.mongodb.com/reference/api/ip-access-list/add-entries-to-access-list/
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              regionUsageRestrictions:
+                default: NONE
+                description: |-
+                  RegionUsageRestrictions designate the project's AWS region when using Atlas for Government.
+                  This parameter should not be used with commercial Atlas.
+                  In Atlas for Government, not setting this field (defaulting to NONE) means the project is restricted to COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                enum:
+                - NONE
+                - GOV_REGIONS_ONLY
+                - COMMERCIAL_FEDRAMP_REGIONS_ONLY
+                type: string
+              settings:
+                description: Settings allow to set Project Settings for the project
+                properties:
+                  isCollectDatabaseSpecificsStatisticsEnabled:
+                    type: boolean
+                  isDataExplorerEnabled:
+                    type: boolean
+                  isExtendedStorageSizesEnabled:
+                    type: boolean
+                  isPerformanceAdvisorEnabled:
+                    type: boolean
+                  isRealtimePerformancePanelEnabled:
+                    type: boolean
+                  isSchemaAdvisorEnabled:
+                    type: boolean
+                type: object
+              teams:
+                description: Teams enable you to grant project access roles to multiple
+                  users.
+                items:
+                  properties:
+                    roles:
+                      description: Roles the users of the team has over the project
+                      items:
+                        enum:
+                        - GROUP_OWNER
+                        - GROUP_CLUSTER_MANAGER
+                        - GROUP_DATA_ACCESS_ADMIN
+                        - GROUP_DATA_ACCESS_READ_WRITE
+                        - GROUP_DATA_ACCESS_READ_ONLY
+                        - GROUP_READ_ONLY
+                        type: string
+                      minItems: 1
+                      type: array
+                    teamRef:
+                      description: Reference to the team which will assigned to the
+                        project
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - roles
+                  - teamRef
+                  type: object
+                type: array
+              withDefaultAlertsSettings:
+                default: true
+                description: Flag that indicates whether to create the new project
+                  with the default alert settings enabled. This parameter defaults
+                  to true
+                type: boolean
+              x509CertRef:
+                description: X509CertRef is the name of the Kubernetes Secret which
+                  contains PEM-encoded CA certificate
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - name
+            type: object
+          status:
+            description: AtlasProjectStatus defines the observed state of AtlasProject
+            properties:
+              alertConfigurations:
+                description: AlertConfigurations contains a list of alert configuration
+                  statuses
+                items:
+                  properties:
+                    acknowledgedUntil:
+                      description: The date through which the alert has been acknowledged.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgementComment:
+                      description: The comment left by the user who acknowledged the
+                        alert. Will not be present if the alert has never been acknowledged.
+                      type: string
+                    acknowledgingUsername:
+                      description: The username of the user who acknowledged the alert.
+                        Will not be present if the alert has never been acknowledged.
+                      type: string
+                    alertConfigId:
+                      description: ID of the alert configuration that triggered this
+                        alert.
+                      type: string
+                    clusterId:
+                      description: The ID of the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    clusterName:
+                      description: The name the cluster to which this alert applies.
+                        Only present for alerts of type BACKUP, REPLICA_SET, and CLUSTER.
+                      type: string
+                    created:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was created.
+                      type: string
+                    currentValue:
+                      description: CurrentValue represents current value of the metric
+                        that triggered the alert. Only present for alerts of type
+                        HOST_METRIC.
+                      properties:
+                        number:
+                          description: The value of the metric.
+                          type: string
+                        units:
+                          description: The units for the value. Depends on the type
+                            of metric.
+                          type: string
+                      type: object
+                    enabled:
+                      description: If omitted, the configuration is disabled.
+                      type: boolean
+                    errorMessage:
+                      description: ErrorMessage is massage if the alert configuration
+                        is in an incorrect state.
+                      type: string
+                    eventTypeName:
+                      description: The type of event that will trigger an alert.
+                      type: string
+                    groupId:
+                      description: Unique identifier of the project that owns this
+                        alert configuration.
+                      type: string
+                    hostId:
+                      description: ID of the host to which the metric pertains. Only
+                        present for alerts of type HOST, HOST_METRIC, and REPLICA_SET.
+                      type: string
+                    hostnameAndPort:
+                      description: The hostname and port of each host to which the
+                        alert applies. Only present for alerts of type HOST, HOST_METRIC,
+                        and REPLICA_SET.
+                      type: string
+                    id:
+                      description: Unique identifier.
+                      type: string
+                    lastNotified:
+                      description: When the last notification was sent for this alert.
+                        Only present if notifications have been sent.
+                      type: string
+                    matchers:
+                      description: You can filter using the matchers array only when
+                        the EventTypeName specifies an event for a host, replica set,
+                        or sharded cluster.
+                      items:
+                        properties:
+                          fieldName:
+                            description: Name of the field in the target object to
+                              match on.
+                            type: string
+                          operator:
+                            description: The operator to test the field’s value.
+                            type: string
+                          value:
+                            description: Value to test with the specified operator.
+                            type: string
+                        type: object
+                      type: array
+                    metricName:
+                      description: The name of the measurement whose value went outside
+                        the threshold. Only present if eventTypeName is set to OUTSIDE_METRIC_THRESHOLD.
+                      type: string
+                    metricThreshold:
+                      description: MetricThreshold  causes an alert to be triggered.
+                      properties:
+                        metricName:
+                          description: Name of the metric to check.
+                          type: string
+                        mode:
+                          description: This must be set to AVERAGE. Atlas computes
+                            the current metric value as an average.
+                          type: string
+                        operator:
+                          description: Operator to apply when checking the current
+                            metric value against the threshold value.
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value.
+                          type: string
+                      required:
+                      - threshold
+                      type: object
+                    notifications:
+                      description: Notifications are sending when an alert condition
+                        is detected.
+                      items:
+                        properties:
+                          apiToken:
+                            description: Slack API token or Bot token. Populated for
+                              the SLACK notifications type. If the token later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the token.
+                            type: string
+                          channelName:
+                            description: Slack channel name. Populated for the SLACK
+                              notifications type.
+                            type: string
+                          datadogApiKey:
+                            description: Datadog API Key. Found in the Datadog dashboard.
+                              Populated for the DATADOG notifications type.
+                            type: string
+                          datadogRegion:
+                            description: Region that indicates which API URL to use
+                            type: string
+                          delayMin:
+                            description: Number of minutes to wait after an alert
+                              condition is detected before sending out the first notification.
+                            type: integer
+                          emailAddress:
+                            description: Email address to which alert notifications
+                              are sent. Populated for the EMAIL notifications type.
+                            type: string
+                          emailEnabled:
+                            description: Flag indicating if email notifications should
+                              be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          flowName:
+                            description: Flowdock flow namse in lower-case letters.
+                            type: string
+                          flowdockApiToken:
+                            description: The Flowdock personal API token. Populated
+                              for the FLOWDOCK notifications type. If the token later
+                              becomes invalid, Atlas sends an email to the project
+                              owner and eventually removes the token.
+                            type: string
+                          intervalMin:
+                            description: Number of minutes to wait between successive
+                              notifications for unacknowledged alerts that are not
+                              resolved.
+                            type: integer
+                          mobileNumber:
+                            description: Mobile number to which alert notifications
+                              are sent. Populated for the SMS notifications type.
+                            type: string
+                          opsGenieApiKey:
+                            description: Opsgenie API Key. Populated for the OPS_GENIE
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the token.
+                            type: string
+                          opsGenieRegion:
+                            description: Region that indicates which API URL to use.
+                            type: string
+                          orgName:
+                            description: Flowdock organization name in lower-case
+                              letters. This is the name that appears after www.flowdock.com/app/
+                              in the URL string. Populated for the FLOWDOCK notifications
+                              type.
+                            type: string
+                          roles:
+                            description: The following roles grant privileges within
+                              a project.
+                            items:
+                              type: string
+                            type: array
+                          serviceKey:
+                            description: PagerDuty service key. Populated for the
+                              PAGER_DUTY notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                          smsEnabled:
+                            description: Flag indicating if text message notifications
+                              should be sent. Populated for ORG, GROUP, and USER notifications
+                              types.
+                            type: boolean
+                          teamId:
+                            description: Unique identifier of a team.
+                            type: string
+                          teamName:
+                            description: Label for the team that receives this notification.
+                            type: string
+                          typeName:
+                            description: Type of alert notification.
+                            type: string
+                          username:
+                            description: Name of the Atlas user to which to send notifications.
+                              Only a user in the project that owns the alert configuration
+                              is allowed here. Populated for the USER notifications
+                              type.
+                            type: string
+                          victorOpsApiKey:
+                            description: VictorOps API key. Populated for the VICTOR_OPS
+                              notifications type. If the key later becomes invalid,
+                              Atlas sends an email to the project owner and eventually
+                              removes the key.
+                            type: string
+                          victorOpsRoutingKey:
+                            description: VictorOps routing key. Populated for the
+                              VICTOR_OPS notifications type. If the key later becomes
+                              invalid, Atlas sends an email to the project owner and
+                              eventually removes the key.
+                            type: string
+                        type: object
+                      type: array
+                    replicaSetName:
+                      description: Name of the replica set. Only present for alerts
+                        of type HOST, HOST_METRIC, BACKUP, and REPLICA_SET.
+                      type: string
+                    resolved:
+                      description: When the alert was closed. Only present if the
+                        status is CLOSED.
+                      type: string
+                    sourceTypeName:
+                      description: For alerts of the type BACKUP, the type of server
+                        being backed up.
+                      type: string
+                    status:
+                      description: 'The current state of the alert. Possible values
+                        are: TRACKING, OPEN, CLOSED, CANCELED'
+                      type: string
+                    threshold:
+                      description: Threshold  causes an alert to be triggered.
+                      properties:
+                        operator:
+                          description: 'Operator to apply when checking the current
+                            metric value against the threshold value. it accepts the
+                            following values: GREATER_THAN, LESS_THAN'
+                          type: string
+                        threshold:
+                          description: Threshold value outside which an alert will
+                            be triggered.
+                          type: string
+                        units:
+                          description: The units for the threshold value
+                          type: string
+                      type: object
+                    updated:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        when this alert configuration was last updated.
+                      type: string
+                  type: object
+                type: array
+              authModes:
+                description: |-
+                  AuthModes contains a list of configured authentication modes
+                  "SCRAM" is default authentication method and requires a password for each user
+                  "X509" signifies that self-managed X.509 authentication is configured
+                items:
+                  type: string
+                type: array
+              cloudProviderIntegrations:
+                description: CloudProviderIntegrations contains a list of configured
+                  cloud provider access roles. AWS support only
+                items:
+                  properties:
+                    atlasAWSAccountArn:
+                      type: string
+                    atlasAssumedRoleExternalId:
+                      type: string
+                    authorizedDate:
+                      type: string
+                    createdDate:
+                      type: string
+                    errorMessage:
+                      type: string
+                    featureUsages:
+                      items:
+                        properties:
+                          featureId:
+                            type: string
+                          featureType:
+                            type: string
+                        type: object
+                      type: array
+                    iamAssumedRoleArn:
+                      type: string
+                    providerName:
+                      type: string
+                    roleId:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                  - atlasAssumedRoleExternalId
+                  - providerName
+                  type: object
+                type: array
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              customRoles:
+                description: CustomRoles contains a list of custom roles statuses
+                items:
+                  properties:
+                    error:
+                      description: The message when the custom role is in the FAILED
+                        status
+                      type: string
+                    name:
+                      description: Role name which is unique
+                      type: string
+                    status:
+                      description: The status of the given custom role (OK or FAILED)
+                      type: string
+                  required:
+                  - name
+                  - status
+                  type: object
+                type: array
+              expiredIpAccessList:
+                description: |-
+                  The list of IP Access List entries that are expired due to 'deleteAfterDate' being less than the current date.
+                  Note, that this field is updated by the Atlas Operator only after specification changes
+                items:
+                  properties:
+                    awsSecurityGroup:
+                      description: Unique identifier of AWS security group in this
+                        access list entry.
+                      type: string
+                    cidrBlock:
+                      description: Range of IP addresses in CIDR notation in this
+                        access list entry.
+                      type: string
+                    comment:
+                      description: Comment associated with this access list entry.
+                      type: string
+                    deleteAfterDate:
+                      description: Timestamp in ISO 8601 date and time format in UTC
+                        after which Atlas deletes the temporary access list entry.
+                      type: string
+                    ipAddress:
+                      description: Entry using an IP address in this access list entry.
+                      type: string
+                  type: object
+                type: array
+              id:
+                description: The ID of the Atlas Project
+                type: string
+              networkPeers:
+                description: The list of network peers that are configured for current
+                  project
+                items:
+                  properties:
+                    atlasGcpProjectId:
+                      description: ProjectID of Atlas container. Applicable only for
+                        GCP. It's needed to add network peer connection.
+                      type: string
+                    atlasNetworkName:
+                      description: Atlas Network Name. Applicable only for GCP. It's
+                        needed to add network peer connection.
+                      type: string
+                    connectionId:
+                      description: Unique identifier of the network peer connection.
+                        Applicable only for AWS.
+                      type: string
+                    containerId:
+                      description: ContainerID of Atlas network peer container.
+                      type: string
+                    errorMessage:
+                      description: Error state of the network peer. Applicable only
+                        for GCP.
+                      type: string
+                    errorState:
+                      description: Error state of the network peer. Applicable only
+                        for Azure.
+                      type: string
+                    errorStateName:
+                      description: Error state of the network peer. Applicable only
+                        for AWS.
+                      type: string
+                    gcpProjectId:
+                      description: ProjectID of the user's vpc. Applicable only for
+                        GCP.
+                      type: string
+                    id:
+                      description: Unique identifier for NetworkPeer.
+                      type: string
+                    providerName:
+                      description: Cloud provider for which you want to retrieve a
+                        network peer.
+                      type: string
+                    region:
+                      description: Region for which you want to create the network
+                        peer. It isn't needed for GCP
+                      type: string
+                    status:
+                      description: Status of the network peer. Applicable only for
+                        GCP and Azure.
+                      type: string
+                    statusName:
+                      description: Status of the network peer. Applicable only for
+                        AWS.
+                      type: string
+                    vpc:
+                      description: |-
+                        VPC is general purpose field for storing the name of the VPC.
+                        VPC is vpcID for AWS, user networkName for GCP, and vnetName for Azure.
+                      type: string
+                  required:
+                  - id
+                  - providerName
+                  - region
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              privateEndpoints:
+                description: The list of private endpoints configured for current
+                  project
+                items:
+                  properties:
+                    endpoints:
+                      description: Collection of individual GCP private endpoints
+                        that comprise your network endpoint group.
+                      items:
+                        properties:
+                          endpointName:
+                            type: string
+                          ipAddress:
+                            type: string
+                          status:
+                            type: string
+                        required:
+                        - endpointName
+                        - ipAddress
+                        - status
+                        type: object
+                      type: array
+                    id:
+                      description: Unique identifier for AWS or AZURE Private Link
+                        Connection.
+                      type: string
+                    interfaceEndpointId:
+                      description: Unique identifier of the AWS or Azure Private Link
+                        Interface Endpoint.
+                      type: string
+                    provider:
+                      description: Cloud provider for which you want to retrieve a
+                        private endpoint service. Atlas accepts AWS or AZURE.
+                      type: string
+                    region:
+                      description: Cloud provider region for which you want to create
+                        the private endpoint service.
+                      type: string
+                    serviceAttachmentNames:
+                      description: Unique alphanumeric and special character strings
+                        that identify the service attachments associated with the
+                        GCP Private Service Connect endpoint service.
+                      items:
+                        type: string
+                      type: array
+                    serviceName:
+                      description: Name of the AWS or Azure Private Link Service that
+                        Atlas manages.
+                      type: string
+                    serviceResourceId:
+                      description: Unique identifier of the Azure Private Link Service
+                        (for AWS the same as ID).
+                      type: string
+                  required:
+                  - provider
+                  - region
+                  type: object
+                type: array
+              prometheus:
+                description: |-
+                  Prometheus contains the status for Prometheus integration
+                  including the prometheusDiscoveryURL
+                properties:
+                  prometheusDiscoveryURL:
+                    type: string
+                  scheme:
+                    type: string
+                type: object
+              teams:
+                description: Teams contains a list of teams assignment statuses
+                items:
+                  properties:
+                    id:
+                      type: string
+                    teamRef:
+                      description: ResourceRefNamespaced is a reference to a Kubernetes
+                        Resource that allows to configure the namespace
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  required:
+                  - teamRef
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlassearchindexconfigs.yaml
@@ -1,0 +1,287 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlassearchindexconfigs.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasSearchIndexConfig
+    listKind: AtlasSearchIndexConfigList
+    plural: atlassearchindexconfigs
+    shortNames:
+    - asic
+    singular: atlassearchindexconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasSearchIndexConfig is the Schema for the AtlasSearchIndexConfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              analyzer:
+                description: |-
+                  Specific pre-defined method chosen to convert database field text into searchable words. This conversion reduces the text of fields into the smallest units of text. These units are called a term or token. This process, known as tokenization, involves a variety of changes made to the text in fields:
+                  - extracting words
+                  - removing punctuation
+                  - removing accents
+                  - hanging to lowercase
+                  - removing common words
+                  - reducing words to their root form (stemming)
+                  - changing words to their base form (lemmatization) MongoDB Cloud uses the selected process to build the Atlas Search index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              analyzers:
+                description: List of user-defined methods to convert database field
+                  text into searchable words
+                items:
+                  properties:
+                    charFilters:
+                      description: Filters that examine text one character at a time
+                        and perform filtering operations
+                      x-kubernetes-preserve-unknown-fields: true
+                    name:
+                      description: |-
+                        Human-readable name that identifies the custom analyzer. Names must be unique within an index, and must not start with any of the following strings:
+                        "lucene.", "builtin.", "mongodb."
+                      type: string
+                    tokenFilters:
+                      description: |-
+                        Filter that performs operations such as:
+                        - Stemming, which reduces related words, such as "talking", "talked", and "talks" to their root word "talk".
+                        - Redaction, the removal of sensitive information from public documents
+                      x-kubernetes-preserve-unknown-fields: true
+                    tokenizer:
+                      description: Tokenizer that you want to use to create tokens.
+                        Tokens determine how Atlas Search splits up text into discrete
+                        chunks for indexing
+                      properties:
+                        group:
+                          description: Index of the character group within the matching
+                            expression to extract into tokens. Use `0` to extract
+                            all character groups.
+                          type: integer
+                        maxGram:
+                          description: Characters to include in the longest token
+                            that Atlas Search creates.
+                          type: integer
+                        maxTokenLength:
+                          description: Maximum number of characters in a single token.
+                            Tokens greater than this length are split at this length
+                            into multiple tokens.
+                          type: integer
+                        minGram:
+                          description: Characters to include in the shortest token
+                            that Atlas Search creates.
+                          type: integer
+                        pattern:
+                          description: Regular expression to match against.
+                          type: string
+                        type:
+                          description: Human-readable label that identifies this tokenizer
+                            type.
+                          enum:
+                          - whitespace
+                          - uaxUrlEmail
+                          - standard
+                          - regexSplit
+                          - regexCaptureGroup
+                          - nGram
+                          - keyword
+                          - edgeGram
+                          type: string
+                      required:
+                      - type
+                      type: object
+                  required:
+                  - name
+                  - tokenizer
+                  type: object
+                type: array
+              searchAnalyzer:
+                description: Method applied to identify words when searching this
+                  index
+                enum:
+                - lucene.standard
+                - lucene.simple
+                - lucene.whitespace
+                - lucene.keyword
+                - lucene.arabic
+                - lucene.armenian
+                - lucene.basque
+                - lucene.bengali
+                - lucene.brazilian
+                - lucene.bulgarian
+                - lucene.catalan
+                - lucene.chinese
+                - lucene.cjk
+                - lucene.czech
+                - lucene.danish
+                - lucene.dutch
+                - lucene.english
+                - lucene.finnish
+                - lucene.french
+                - lucene.galician
+                - lucene.german
+                - lucene.greek
+                - lucene.hindi
+                - lucene.hungarian
+                - lucene.indonesian
+                - lucene.irish
+                - lucene.italian
+                - lucene.japanese
+                - lucene.korean
+                - lucene.kuromoji
+                - lucene.latvian
+                - lucene.lithuanian
+                - lucene.morfologik
+                - lucene.nori
+                - lucene.norwegian
+                - lucene.persian
+                - lucene.portuguese
+                - lucene.romanian
+                - lucene.russian
+                - lucene.smartcn
+                - lucene.sorani
+                - lucene.spanish
+                - lucene.swedish
+                - lucene.thai
+                - lucene.turkish
+                - lucene.ukrainian
+                type: string
+              storedSource:
+                description: |-
+                  Flag that indicates whether to store all fields (true) on Atlas Search. By default, Atlas doesn't store (false) the fields on Atlas Search. Alternatively, you can specify an object that only contains the list of fields to store (include) or not store (exclude) on Atlas Search. To learn more, see documentation:
+                  https://www.mongodb.com/docs/atlas/atlas-search/stored-source-definition/
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasstreamconnections.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasstreamconnections.yaml
@@ -1,0 +1,242 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreamconnections.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamConnection
+    listKind: AtlasStreamConnectionList
+    plural: atlasstreamconnections
+    shortNames:
+    - asc
+    singular: atlasstreamconnection
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamConnection is the Schema for the atlasstreamconnections
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  name:
+                    description: Name of the cluster configured for this connection
+                    type: string
+                  role:
+                    description: The name of a Built in or Custom DB Role to connect
+                      to an Atlas Cluster
+                    properties:
+                      name:
+                        description: The name of the role to use. Can be a built in
+                          role or a custom role
+                        type: string
+                      type:
+                        description: Type of the DB role. Can be either BuiltIn or
+                          Custom
+                        enum:
+                        - BUILT_IN
+                        - CUSTOM
+                        type: string
+                    required:
+                    - name
+                    - type
+                    type: object
+                required:
+                - name
+                - role
+                type: object
+              kafkaConfig:
+                description: The configuration to be used to connect to a Kafka Cluster
+                properties:
+                  authentication:
+                    description: User credentials required to connect to a Kafka Cluster.
+                      Includes the authentication type, as well as the parameters
+                      for that authentication mode
+                    properties:
+                      credentials:
+                        description: Reference to the secret containing th Username
+                          and Password of the account to connect to the Kafka cluster.
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      mechanism:
+                        description: Style of authentication. Can be one of PLAIN,
+                          SCRAM-256, or SCRAM-512
+                        enum:
+                        - PLAIN
+                        - SCRAM-256
+                        - SCRAM-512
+                        type: string
+                    required:
+                    - credentials
+                    - mechanism
+                    type: object
+                  bootstrapServers:
+                    description: Comma separated list of server addresses
+                    type: string
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: A map of Kafka key-value pairs for optional configuration.
+                      This is a flat object, and keys can have '.' characters
+                    type: object
+                  security:
+                    description: Properties for the secure transport connection to
+                      Kafka. For SSL, this can include the trusted certificate to
+                      use
+                    properties:
+                      certificate:
+                        description: A trusted, public x509 certificate for connecting
+                          to Kafka over SSL
+                        properties:
+                          name:
+                            description: Name is the name of the Kubernetes Resource
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the Kubernetes
+                              Resource
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      protocol:
+                        description: Describes the transport type. Can be either PLAINTEXT
+                          or SSL
+                        enum:
+                        - PLAINTEXT
+                        - SSL
+                        type: string
+                    required:
+                    - protocol
+                    type: object
+                required:
+                - authentication
+                - bootstrapServers
+                - security
+                type: object
+              name:
+                description: Human-readable label that uniquely identifies the stream
+                  connection
+                type: string
+              type:
+                description: Type of the connection. Can be either Cluster or Kafka
+                enum:
+                - Kafka
+                - Cluster
+                - Sample
+                type: string
+            required:
+            - name
+            - type
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              instances:
+                description: List of instances using the connection configuration
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasstreaminstances.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasstreaminstances.yaml
@@ -1,0 +1,213 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasstreaminstances.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasStreamInstance
+    listKind: AtlasStreamInstanceList
+    plural: atlasstreaminstances
+    shortNames:
+    - asi
+    singular: atlasstreaminstance
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasStreamInstance is the Schema for the atlasstreaminstances
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              clusterConfig:
+                description: The configuration to be used to connect to a Atlas Cluster
+                properties:
+                  provider:
+                    default: AWS
+                    description: Name of the cluster configured for this connection
+                    enum:
+                    - AWS
+                    - GCP
+                    - AZURE
+                    - TENANT
+                    - SERVERLESS
+                    type: string
+                  region:
+                    description: Name of the cloud provider region hosting Atlas Stream
+                      Processing.
+                    type: string
+                  tier:
+                    default: SP10
+                    description: Selected tier for the Stream Instance. Configures
+                      Memory / VCPU allowances.
+                    enum:
+                    - SP10
+                    - SP30
+                    - SP50
+                    type: string
+                required:
+                - provider
+                - region
+                - tier
+                type: object
+              connectionRegistry:
+                description: List of connections of the stream instance for the specified
+                  project
+                items:
+                  description: ResourceRefNamespaced is a reference to a Kubernetes
+                    Resource that allows to configure the namespace
+                  properties:
+                    name:
+                      description: Name is the name of the Kubernetes Resource
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Kubernetes Resource
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Human-readable label that identifies the stream connection
+                type: string
+              projectRef:
+                description: Project which the instance belongs to
+                properties:
+                  name:
+                    description: Name is the name of the Kubernetes Resource
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of the Kubernetes Resource
+                    type: string
+                required:
+                - name
+                type: object
+            required:
+            - clusterConfig
+            - name
+            - projectRef
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              connections:
+                description: List of connections configured in the stream instance.
+                items:
+                  properties:
+                    name:
+                      description: Human-readable label that uniquely identifies the
+                        stream connection
+                      type: string
+                    resourceRef:
+                      description: Reference for the resource that contains connection
+                        configuration
+                      properties:
+                        name:
+                          description: Name is the name of the Kubernetes Resource
+                          type: string
+                        namespace:
+                          description: Namespace is the namespace of the Kubernetes
+                            Resource
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
+              hostnames:
+                description: List that contains the hostnames assigned to the stream
+                  instance.
+                items:
+                  type: string
+                type: array
+              id:
+                description: Unique 24-hexadecimal character string that identifies
+                  the instance
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasteams.yaml
+++ b/internal/kubernetes/operator/crds/versions/v2.7.0/atlas.mongodb.com_atlasteams.yaml
@@ -1,0 +1,144 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: mongodb-atlas-kubernetes-operator
+    app.kubernetes.io/name: mongodb-atlas-kubernetes-operator
+  name: atlasteams.atlas.mongodb.com
+spec:
+  group: atlas.mongodb.com
+  names:
+    categories:
+    - atlas
+    kind: AtlasTeam
+    listKind: AtlasTeamList
+    plural: atlasteams
+    shortNames:
+    - at
+    singular: atlasteam
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.name
+      name: Name
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.id
+      name: Atlas ID
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: AtlasTeam is the Schema for the Atlas Teams API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TeamSpec defines the desired state of a Team in Atlas
+            properties:
+              name:
+                description: The name of the team you want to create.
+                type: string
+              usernames:
+                description: Valid email addresses of users to add to the new team
+                items:
+                  format: email
+                  type: string
+                type: array
+            required:
+            - name
+            - usernames
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions is the list of statuses showing the current
+                  state of the Atlas Custom Resource
+                items:
+                  description: Condition describes the state of an Atlas Custom Resource
+                    at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of Atlas Custom Resource condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              id:
+                description: ID of the team
+                type: string
+              observedGeneration:
+                description: |-
+                  ObservedGeneration indicates the generation of the resource specification that the Atlas Operator is aware of.
+                  The Atlas Operator updates this field to the 'metadata.generation' as soon as it starts reconciliation of the resource.
+                format: int64
+                type: integer
+              projects:
+                description: List of projects which the team is assigned
+                items:
+                  properties:
+                    id:
+                      description: Unique identifier of the project inside atlas
+                      type: string
+                    name:
+                      description: Name given to the project
+                      type: string
+                  required:
+                  - id
+                  - name
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/internal/kubernetes/operator/features/embeded_test.go
+++ b/internal/kubernetes/operator/features/embeded_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package features_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/mongodb/atlas-cli-plugin-kubernetes/internal/kubernetes/operator/crds"
+	"github.com/mongodb/atlas-cli-plugin-kubernetes/internal/kubernetes/operator/features"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	urlTemplate    = "https://raw.githubusercontent.com/mongodb/mongodb-atlas-kubernetes/v%s/bundle/manifests/atlas.mongodb.com_%s.yaml"
+	requestTimeout = 10 * time.Second
+)
+
+func TestEmbeddedCRDs(t *testing.T) {
+	client := http.Client{}
+	provider := crds.EmbeddedAtlasCRDProvider{}
+	diffs := []string{}
+	for _, version := range features.SupportedVersions() {
+		resources, ok := features.GetResourcesForVersion(version)
+		require.True(t, ok)
+		for _, resource := range resources {
+			if diffResource(t, &client, provider, version, resource) {
+				diffs = append(diffs, fmt.Sprintf("%s/%s", version, resource))
+			}
+		}
+	}
+	assert.Equal(t, []string{}, diffs)
+}
+
+func diffResource(t *testing.T, httpClient *http.Client, provider crds.AtlasOperatorCRDProvider, version, resource string) bool {
+	localCRD, err := provider.GetAtlasOperatorResource(resource, version)
+	require.NoError(t, err)
+	remoteCRD, err := getGitHubCRD(httpClient, resource, version)
+	require.NoError(t, err)
+	return !reflect.DeepEqual(localCRD, remoteCRD)
+}
+
+func getGitHubCRD(httpClient *http.Client, resource, version string) (*v1.CustomResourceDefinition, error) {
+	ctx, cancelF := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancelF()
+
+	url := fmt.Sprintf(urlTemplate, version, resource)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare request GET %s: %w", url, err)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to GET %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data from GET %s: %w", url, err)
+	}
+
+	decoded := &apiextensionsv1.CustomResourceDefinition{}
+	err = yaml.Unmarshal(data, decoded)
+	if err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}


### PR DESCRIPTION
We do not really need to query Github to check the CRDs, better to embed them within the plugin to avoid such a external dependency.

1. In `provider.go` we replace `GithubAtlasCRDProvider` with `EmbeddedAtlasCRDProvider` as an implementation of `crds.AtlasOperatorCRDProvider`.
2. Usages need to change in `generate.go` and `install.go`.
3. Testing happens in `features`'s `embedding_test.go`, which validates the embedded files match the GitHub files in the tagged releases.
4. Rest of files are just the embedded files added within `crds/versions`.

<!--
Thanks for contributing to Atlas CLI Kubernetes Plugin!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and get you pull request merged!
-->

## Proposed changes

<!-- 
Describe the big picture of your changes here and communicate why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue. 
-->

_Jira ticket:_ CLOUDP-303050


## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
