### PR TITLE
CLOUDP-314963: Don't expect Atlas Alert config when unset

### DIFF
--- a/test/e2e/kubernetes_config_generate_test.go
+++ b/test/e2e/kubernetes_config_generate_test.go
@@ -175,7 +175,7 @@ func TestExportIndependentOrNot(t *testing.T) {
 	testPrefix := "test-"
 	generator.generateDBUser(testPrefix)
 	generator.generateCluster()
-	expectAlertConfigs := true
+	expectAlertConfigs := false
 	dictionary := resources.AtlasNameToKubernetesName()
 	credentialName := resources.NormalizeAtlasName(generator.projectName+credSuffixTest, dictionary)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Atlas CLI Kubernetes Plugin!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and get you pull request merged!
-->

## Proposed changes

Seems that Atlas might have decided to fully honor the `WithDefaultAlertsSettings` flag at group creation. Now when queried about a project created with such flag, the reply includes an empty setting about alter config, instead of a fully populated set of defaults.

_Jira ticket:_ CLOUDP-314963

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.

Alternatively, if this is a very minor, and self-explanatory change, feel free to remove this section.
-->
