### PR TITLE
further copybara changes

### DIFF
--- a/build/ci/copy.bara.sky.template
+++ b/build/ci/copy.bara.sky.template
@@ -32,7 +32,7 @@ core.workflow(
 )
  
 core.workflow(
-    name = "docs-atlas-cli",
+    name = "docs-mongodb-internal",
     origin = git.origin(
         url = source_url,
         ref = release_tag,

--- a/build/ci/release.yml
+++ b/build/ci/release.yml
@@ -152,12 +152,12 @@ tasks:
       - command: github.generate_token
         params:
           expansion_name: docs_atlas_cli_token
-          owner: mongodb
-          repo: docs-atlas-cli
+          owner: 10gen
+          repo: docs-mongodb-internal
       - func: "run-copybara"
         vars:
           gh_token: ${docs_atlas_cli_token}
-          workflow: docs-atlas-cli
+          workflow: docs-mongodb-internal
       - command: github.generate_token
         params:
           expansion_name: cloud_docs_token


### PR DESCRIPTION
additional fixes based on Atlas CLI changes in https://github.com/mongodb/mongodb-atlas-cli/pull/3995. Note that this task might fail due a lack of copybara history for the new repo. We're working on getting that fixed, but it might be Monday before we can manage (we're still getting versions squared away after the migration).