### PR TITLE
fix: remove release warning for missing variants

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -344,18 +344,9 @@ buildvariants:
       <<: *go_linux_version
     tasks:
       - name: ".e2e .required"
-patch_aliases:
-  - alias: "cleanup"
-    variant_tags: ["cleanup cron"]
-    task: ".*"
-  - alias: "snyk"
-    variant_tags: ["snyk cron"]
-    task: ".*"
 github_pr_aliases:
   - variant: "code_health"
     task_tags: ["code_health"]
-  - variant: "e2e_generic"
-    task_tags: ["e2e", "generic"]
   - variant: "e2e_required"
     task_tags: ["e2e", "required"]
 git_tag_aliases:


### PR DESCRIPTION
<!--
Thanks for contributing to Atlas CLI Kubernetes Plugin!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and get you pull request merged!
-->

## Proposed changes

Remove code that generated release warning (snyk and generic_e2e are never used): 
`GitHub PR alias (from the project page) matching variant regexp 'e2e_generic' has no matching variants
Patch alias 'snyk' (from the yaml) matching variant tags '[snyk cron]' has no matching variants` 

_Jira ticket:_ CLOUDP-#

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

This just fixes some warning from release.
