### PR TITLE
CLOUDP-331768: List the full max page size by default

### DIFF
--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -70,7 +70,7 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 			},
 			ClusterType:              pointer.Get("REPLICASET"),
 			ConnectionStrings:        nil,
-			DiskSizeGB:               pointer.Get[float64](20.4),
+			DiskSizeGB:               pointer.Get(20.4),
 			EncryptionAtRestProvider: pointer.Get("TestProvider"),
 			GroupId:                  pointer.Get("TestGroupID"),
 			Id:                       pointer.Get("TestID"),
@@ -148,7 +148,7 @@ func TestBuildAtlasAdvancedDeployment(t *testing.T) {
 			SampleRefreshIntervalBIConnector: pointer.Get(10),
 		}
 		processArgs.OplogSizeMB = pointer.Get(10)
-		processArgs.OplogMinRetentionHours = pointer.Get[float64](10.1)
+		processArgs.OplogMinRetentionHours = pointer.Get(10.1)
 		backupSchedule := &atlasClustersPinned.DiskBackupSnapshotSchedule{
 			ClusterId:             pointer.Get("testClusterID"),
 			ClusterName:           pointer.Get(clusterName),

--- a/internal/store/clusters.go
+++ b/internal/store/clusters.go
@@ -39,7 +39,7 @@ type AtlasClusterConfigurationOptionsDescriber interface {
 func (s *Store) ProjectClusters(projectID string, opts *ListOptions) (*atlasClustersPinned.PaginatedAdvancedClusterDescription, error) {
 	res := s.clientClusters.ClustersApi.ListClusters(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(fixPageSize(opts.ItemsPerPage)).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/database_users.go
+++ b/internal/store/database_users.go
@@ -27,7 +27,7 @@ type DatabaseUserLister interface {
 func (s *Store) DatabaseUsers(projectID string, opts *ListOptions) (*atlasv2.PaginatedApiAtlasDatabaseUser, error) {
 	res := s.clientv2.DatabaseUsersApi.ListDatabaseUsers(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(fixPageSize(opts.ItemsPerPage)).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/integrations.go
+++ b/internal/store/integrations.go
@@ -51,7 +51,7 @@ type getPageFn[T any] func(int, int) ([]T, error)
 func AllPages[T any](getPageFn getPageFn[T]) ([]T, error) {
 	allPages := []T{}
 	pageNum := 1
-	itemsPerPage := MaxItems
+	itemsPerPage := MaxAPIPageSize
 	for {
 		page, err := getPageFn(pageNum, itemsPerPage)
 		if err != nil {

--- a/internal/store/network_containers.go
+++ b/internal/store/network_containers.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	MaxItems = 500
+	MaxAPIPageSize = 500
 )
 
 var (
@@ -56,7 +56,7 @@ func (s *Store) NetworkContainers(projectID string) ([]atlasv2.CloudProviderCont
 func (s *Store) networkContainersFor(projectID string, provider akov2provider.ProviderName) ([]atlasv2.CloudProviderContainer, error) {
 	allPages := []atlasv2.CloudProviderContainer{}
 	pageNum := 1
-	itemsPerPage := MaxItems
+	itemsPerPage := MaxAPIPageSize
 	for {
 		result, _, err := s.clientv2.NetworkPeeringApi.ListPeeringContainerByCloudProvider(s.ctx, projectID).
 			ItemsPerPage(itemsPerPage).

--- a/internal/store/project_ip_access_lists.go
+++ b/internal/store/project_ip_access_lists.go
@@ -28,7 +28,7 @@ type ProjectIPAccessListLister interface {
 func (s *Store) ProjectIPAccessLists(projectID string, opts *ListOptions) (*atlasv2.PaginatedNetworkAccess, error) {
 	res := s.clientv2.ProjectIPAccessListApi.ListProjectIpAccessLists(s.ctx, projectID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage).IncludeCount(opts.IncludeCount)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(fixPageSize(opts.ItemsPerPage)).IncludeCount(opts.IncludeCount)
 	}
 	result, _, err := res.Execute()
 	return result, err

--- a/internal/store/projects.go
+++ b/internal/store/projects.go
@@ -46,7 +46,7 @@ type ProjectTeamLister interface {
 func (s *Store) Projects(opts *ListOptions) (*atlasv2.PaginatedAtlasGroup, error) {
 	res := s.clientv2.ProjectsApi.ListProjects(s.ctx)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(fixPageSize(opts.ItemsPerPage))
 	}
 	result, _, err := res.Execute()
 	return result, err
@@ -56,7 +56,7 @@ func (s *Store) Projects(opts *ListOptions) (*atlasv2.PaginatedAtlasGroup, error
 func (s *Store) GetOrgProjects(orgID string, opts *ListOptions) (*atlasv2.PaginatedAtlasGroup, error) {
 	res := s.clientv2.OrganizationsApi.ListOrganizationProjects(s.ctx, orgID)
 	if opts != nil {
-		res = res.PageNum(opts.PageNum).ItemsPerPage(opts.ItemsPerPage)
+		res = res.PageNum(opts.PageNum).ItemsPerPage(fixPageSize(opts.ItemsPerPage))
 	}
 	result, _, err := res.Execute()
 	return result, err
@@ -88,9 +88,16 @@ func (s *Store) ProjectTeams(projectID string, opts *ListOptions) (*atlasv2.Pagi
 		res.
 			IncludeCount(opts.IncludeCount).
 			PageNum(opts.PageNum).
-			ItemsPerPage(opts.ItemsPerPage)
+			ItemsPerPage(fixPageSize(opts.ItemsPerPage))
 	}
 
 	result, _, err := res.Execute()
 	return result, err
+}
+
+func fixPageSize(itemsPerPage int) int {
+	if itemsPerPage < 1 {
+		return MaxAPIPageSize
+	}
+	return itemsPerPage
 }

--- a/internal/store/serverless_instances.go
+++ b/internal/store/serverless_instances.go
@@ -37,7 +37,7 @@ func (s *Store) ServerlessInstances(projectID string, listOps *ListOptions) (*at
 		return nil, fmt.Errorf("%w: %s", errUnsupportedService, s.service)
 	}
 	result, _, err := s.clientClusters.ServerlessInstancesApi.ListServerlessInstances(s.ctx, projectID).
-		ItemsPerPage(listOps.ItemsPerPage).
+		ItemsPerPage(fixPageSize(listOps.ItemsPerPage)).
 		PageNum(listOps.PageNum).
 		IncludeCount(listOps.IncludeCount).
 		Execute()

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -18,6 +18,7 @@ package e2e
 
 import (
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -48,6 +49,9 @@ func KubernetesPlugin(t *testing.T) {
 
 func AtlasCLIBin() (string, error) {
 	path := os.Getenv("E2E_ATLASCLI_BINARY_PATH")
+	if path == "" {
+		return "", errors.New("invalid empty bin path")
+	}
 	cliPath, err := filepath.Abs(path)
 	if err != nil {
 		return "", fmt.Errorf("%w: invalid bin path %q", err, path)

--- a/test/e2e/kubernetes_config_generate_test.go
+++ b/test/e2e/kubernetes_config_generate_test.go
@@ -929,12 +929,6 @@ func defaultIPAccessList(generator *atlasE2ETestGenerator, independent bool) *ak
 	return ial
 }
 
-func expectedWithIPAccessList(p *akov2.AtlasProject, ial []akov2project.IPAccessList) *akov2.AtlasProject {
-	p.Spec.ProjectIPAccessList = ial
-
-	return p
-}
-
 type filtered []runtime.Object
 
 func (f filtered) byKind(kinds ...string) []runtime.Object {
@@ -3044,4 +3038,48 @@ func checkDataFederationData(t *testing.T, dataFederations []*akov2.AtlasDataFed
 		}
 	}
 	assert.ElementsMatch(t, dataFedNames, entries)
+}
+
+func TestGenerateMany(t *testing.T) {
+	// always register atlas entities
+	require.NoError(t, akov2.AddToScheme(scheme.Scheme))
+
+	projectID, projectName := mustGenerateTestProject(t)
+	defer clearTestProject(t, projectID)
+	user1 := generateTestDBUser(t, projectID)
+	user2 := generateTestDBUser(t, projectID)
+	flex1 := generateTestFlexCluster(t, projectID)
+	defer clearTestCluster(t, projectID, flex1)
+	flex2 := generateTestFlexCluster(t, projectID)
+	defer clearTestCluster(t, projectID, flex2)
+
+	cliPath, err := PluginBin()
+	require.NoError(t, err)
+	cmd := exec.Command(cliPath,
+		"kubernetes",
+		"config",
+		"generate",
+		"--projectId",
+		projectID,
+		"--targetNamespace",
+		targetNamespace,
+		"--independentResources") // independent resources generating the project ID is required for this test
+	cmd.Env = os.Environ()
+
+	resp, err := test.RunAndGetStdOut(cmd)
+	t.Log(string(resp))
+	require.NoError(t, err, string(resp))
+
+	var objects []runtime.Object
+	objects, err = getK8SEntities(resp)
+	require.NoError(t, err, "should not fail on decode")
+	require.NotEmpty(t, objects, "result should not be empty")
+
+	assert.NotNil(t, findGeneratedProject(objects, projectName))
+	for i, user := range []string{user1, user2} {
+		assert.NotNil(t, findGeneratedUser(objects, projectID, user), "not found user %d", i)
+	}
+	for i, flex := range []string{flex1, flex2} {
+		assert.NotNil(t, findGeneratedFlexCluster(objects, projectName, flex), "not found flex cluster %d", i)
+	}
 }


### PR DESCRIPTION
## Proposed changes

If left to defaults, the list calls will return 1 result when `ItemsPerPage` is 0. The fix ensures `ItemsPerPage` is set to `MaxAPIPageSize`, that is `500` instead of `0`. 

_Jira ticket:_ CLOUDP-331768

## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [ ] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [X] I have run `make fmt` and formatted my code

