### PR TITLE
CLOUDP-331757: Switch test environment variables

### DIFF
--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -84,6 +84,12 @@ functions:
         include_expansions_in_env:
           - go_base_path
           - workdir
+          - ATLAS_TEST_ENV
+          - QA_MCLI_ORG_ID
+          - QA_MCLI_PROJECT_ID
+          - QA_MCLI_PRIVATE_API_KEY
+          - QA_MCLI_PUBLIC_API_KEY
+          - QA_MCLI_OPS_MANAGER_URL
           - MCLI_ORG_ID
           - MCLI_PROJECT_ID
           - MCLI_PRIVATE_API_KEY
@@ -238,6 +244,12 @@ tasks:
             EOF
       - func: "e2e test"
         vars:
+          ATLAS_TEST_ENV: ${atlas_test_env} # "QA" activates the switch, anything else fallbacks to DEV
+          QA_MCLI_ORG_ID: ${qa_atlas_org_id}
+          QA_MCLI_PROJECT_ID: ${qa_atlas_project_id}
+          QA_MCLI_PRIVATE_API_KEY: ${qa_atlas_private_api_key}
+          QA_MCLI_PUBLIC_API_KEY: ${qa_atlas_public_api_key}
+          QA_MCLI_OPS_MANAGER_URL: ${qa_mcli_ops_manager_url}
           MCLI_ORG_ID: ${atlas_org_id}
           MCLI_PROJECT_ID: ${atlas_project_id}
           MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
@@ -262,6 +274,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
+          ATLAS_TEST_ENV: ${atlas_test_env} # "QA" activates the switch, anything else fallbacks to DEV
+          QA_MCLI_ORG_ID: ${qa_atlas_org_id}
+          QA_MCLI_PROJECT_ID: ${qa_atlas_project_id}
+          QA_MCLI_PRIVATE_API_KEY: ${qa_atlas_private_api_key}
+          QA_MCLI_PUBLIC_API_KEY: ${qa_atlas_public_api_key}
+          QA_MCLI_OPS_MANAGER_URL: ${qa_mcli_ops_manager_url}
           MCLI_ORG_ID: ${atlas_org_id}
           MCLI_PROJECT_ID: ${atlas_project_id}
           MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
@@ -286,6 +304,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
+          ATLAS_TEST_ENV: ${atlas_test_env} # "QA" activates the switch, anything else fallbacks to DEV
+          QA_MCLI_ORG_ID: ${qa_atlas_org_id}
+          QA_MCLI_PROJECT_ID: ${qa_atlas_project_id}
+          QA_MCLI_PRIVATE_API_KEY: ${qa_atlas_private_api_key}
+          QA_MCLI_PUBLIC_API_KEY: ${qa_atlas_public_api_key}
+          QA_MCLI_OPS_MANAGER_URL: ${qa_mcli_ops_manager_url}
           MCLI_ORG_ID: ${atlas_org_id}
           MCLI_PROJECT_ID: ${atlas_project_id}
           MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}
@@ -310,6 +334,12 @@ tasks:
       - func: "install gotestsum"
       - func: "e2e test"
         vars:
+          ATLAS_TEST_ENV: ${atlas_test_env} # "QA" activates the switch, anything else fallbacks to DEV
+          QA_MCLI_ORG_ID: ${qa_atlas_org_id}
+          QA_MCLI_PROJECT_ID: ${qa_atlas_project_id}
+          QA_MCLI_PRIVATE_API_KEY: ${qa_atlas_private_api_key}
+          QA_MCLI_PUBLIC_API_KEY: ${qa_atlas_public_api_key}
+          QA_MCLI_OPS_MANAGER_URL: ${qa_mcli_ops_manager_url}
           MCLI_ORG_ID: ${atlas_org_id}
           MCLI_PROJECT_ID: ${atlas_project_id}
           MCLI_PRIVATE_API_KEY: ${atlas_private_api_key}

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build e2e || apply || generate || install
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	if isQASelected() {
+		setQACredentialsEnvVars()
+	}
+	exitVal := m.Run()
+	restoreEnvVars()
+	os.Exit(exitVal)
+}
+
+func TestEnv(t *testing.T) {
+	if isQASelected() {
+		t.Run("Switched to run on cloud-qa", func(_ *testing.T) {})
+	} else {
+		t.Run("Running on cloud-dev (default)" , func(_ *testing.T) {})
+	}
+}
+
+func isQASelected() bool {
+	return os.Getenv("ATLAS_TEST_ENV") == "QA" && areQASettingsPresent()
+}
+
+func areQASettingsPresent() bool {
+	return hasEnv("QA_MCLI_ORG_ID") &&
+		hasEnv("QA_MCLI_OPS_MANAGER_URL") &&
+		hasEnv("QA_MCLI_PROJECT_ID") &&
+		hasEnv("QA_MCLI_PUBLIC_API_KEY") &&
+		hasEnv("QA_MCLI_PRIVATE_API_KEY")
+}
+
+func hasEnv(envvar string) bool {
+	_, ok := os.LookupEnv(envvar)
+	return ok
+}
+
+func setQACredentialsEnvVars() {
+	saveEnv("MCLI_ORG_ID")
+	saveEnv("MCLI_OPS_MANAGER_URL")
+	saveEnv("MCLI_PROJECT_ID")
+	saveEnv("MCLI_PUBLIC_API_KEY")
+	saveEnv("MCLI_PRIVATE_API_KEY")
+	os.Setenv("MCLI_ORG_ID", os.Getenv("QA_MCLI_ORG_ID"))
+	os.Setenv("MCLI_OPS_MANAGER_URL", os.Getenv("QA_MCLI_OPS_MANAGER_URL"))
+	os.Setenv("MCLI_PROJECT_ID", os.Getenv("QA_MCLI_PROJECT_ID"))
+	os.Setenv("MCLI_PUBLIC_API_KEY", os.Getenv("QA_MCLI_PUBLIC_API_KEY"))
+	os.Setenv("MCLI_PRIVATE_API_KEY", os.Getenv("QA_MCLI_PRIVATE_API_KEY"))
+}
+
+func restoreEnvVars() {
+	restoreEnv("MCLI_ORG_ID")
+	restoreEnv("MCLI_OPS_MANAGER_URL")
+	restoreEnv("MCLI_PROJECT_ID")
+	restoreEnv("MCLI_PUBLIC_API_KEY")
+	restoreEnv("MCLI_PRIVATE_API_KEY")
+}
+
+func saveEnv(envvar string) {
+	os.Setenv(savedEnvVar(envvar), os.Getenv(envvar))
+}
+
+func restoreEnv(envvar string) {
+	os.Setenv(envvar, os.Getenv(savedEnvVar(envvar)))
+}
+
+func savedEnvVar(envvar string) string {
+	return fmt.Sprintf("%s_SAVED", envvar)
+}


### PR DESCRIPTION
## Proposed changes

Allow us to change to test in `cloud-qa` when the `ATLAS_TEST_ENV` is set to `QA`.
_Jira ticket:_ CLOUDP-331757

## Checklist

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [X] I have run `make fmt` and formatted my code

## Further comments

Will test changing the env vars to test in QA.
