### PR TITLE
Remove go build tags for unit and e2e tests and run tests by their names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,13 @@ MANIFEST_FILE?=manifest.yml
 WIN_MANIFEST_FILE?=manifest.windows.yml
 
 TEST_CMD?=go test
-UNIT_TAGS?=unit
 COVERAGE?=coverage.out
 
 E2E_PLUGIN_BINARY_PATH=../../$(PLUGIN_BINARY_PATH)
-E2E_TAGS?=e2e
 E2E_TIMEOUT?=60m
 E2E_PARALLEL?=1
 E2E_EXTRA_ARGS?=
+E2E_RUN_PATTERN?=.*
 
 export E2E_PLUGIN_BINARY_PATH
 export E2E_ATLASCLI_BINARY_PATH
@@ -63,12 +62,12 @@ lint: ## Run linter
 .PHONY: unit-test
 unit-test: ## Run unit-tests
 	@echo "==> Running unit tests..."
-	$(TEST_CMD) --tags="$(UNIT_TAGS)" -race -cover -coverprofile $(COVERAGE) -count=1 ./...
+	$(TEST_CMD) -race -cover -coverprofile $(COVERAGE) -count=1 ./internal/... ./cmd/...
 
 .PHONY: fuzz-normalizer-test
 fuzz-normalizer-test: ## Run fuzz test
 	@echo "==> Running fuzz test..."
-	$(TEST_CMD) -fuzz=Fuzz -fuzztime 50s --tags="$(UNIT_TAGS)" -race ./internal/kubernetes/operator/resources
+	$(TEST_CMD) -fuzz=Fuzz -fuzztime 50s -race ./internal/kubernetes/operator/resources
 
 .PHONY: build-debug
 build-debug: ## Generate a binary in ./bin for debugging plugin
@@ -80,7 +79,7 @@ e2e-test: build-debug ## Run E2E tests
 # the target assumes the MCLI_* environment variables are exported
 	@./scripts/atlas-binary.sh
 	@echo "==> Running E2E tests..."
-	GOCOVERDIR=$(GOCOVERDIR) $(TEST_CMD) -race -v -p 1 -parallel $(E2E_PARALLEL) -v -timeout $(E2E_TIMEOUT) -tags="$(E2E_TAGS)" ./test/e2e... $(E2E_EXTRA_ARGS)
+	GOCOVERDIR=$(GOCOVERDIR) $(TEST_CMD) -race -v -p 1 -parallel $(E2E_PARALLEL) -v -timeout $(E2E_TIMEOUT) -run="$(E2E_RUN_PATTERN)" ./test/e2e... $(E2E_EXTRA_ARGS)
 
 .PHONY: gen-mocks
 gen-mocks: ## Generate mocks

--- a/build/ci/evergreen.yml
+++ b/build/ci/evergreen.yml
@@ -94,7 +94,7 @@ functions:
           - MCLI_PUBLIC_API_KEY
           - MCLI_SERVICE
           - TEST_CMD
-          - E2E_TAGS
+          - E2E_RUN_PATTERN
           - MCLI_OPS_MANAGER_URL
           - OM_VERSION
           - LOCAL_KEY
@@ -262,7 +262,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${azure_client_secret}
           GOOGLE_PROJECT_ID: ${google_project_id}
           GCP_SA_CRED: ${gcp_sa_cred}
-          E2E_TAGS: atlas,cli
+          E2E_RUN_PATTERN: TestKubernetesPluginBinary
   - name: atlas_kubernetes_generate_e2e
     tags: ["e2e","required","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas"]
     must_have_test_results: true
@@ -290,7 +290,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${azure_client_secret}
           GOOGLE_PROJECT_ID: ${google_project_id}
           GCP_SA_CRED: ${gcp_sa_cred}
-          E2E_TAGS: generate
+          E2E_RUN_PATTERN: TestExport.*|TestGenerate.*|TestProject.*|TestFederatedAuthTest|TestEmptyProject|TestKubernetesConfigGenerate.*
   - name: atlas_kubernetes_apply_e2e
     tags: [ "e2e","required","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
     must_have_test_results: true
@@ -318,7 +318,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${azure_client_secret}
           GOOGLE_PROJECT_ID: ${google_project_id}
           GCP_SA_CRED: ${gcp_sa_cred}
-          E2E_TAGS: apply
+          E2E_RUN_PATTERN: TestKubernetesConfigApply.*
   - name: atlas_kubernetes_install_e2e
     tags: [ "e2e","required","kubernetes", "assigned_to_jira_team_cloudp_kubernetes_atlas" ]
     must_have_test_results: true
@@ -346,7 +346,7 @@ tasks:
           AZURE_CLIENT_SECRET: ${azure_client_secret}
           GOOGLE_PROJECT_ID: ${google_project_id}
           GCP_SA_CRED: ${gcp_sa_cred}
-          E2E_TAGS: install
+          E2E_RUN_PATTERN: TestKubernetesOperatorInstall
 buildvariants:
   - name: code_health
     display_name: "Code Health"

--- a/internal/cli/kubernetes/config/apply_test.go
+++ b/internal/cli/kubernetes/config/apply_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package config
 

--- a/internal/cli/kubernetes/config/generate_test.go
+++ b/internal/cli/kubernetes/config/generate_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package config
 

--- a/internal/cli/kubernetes/operator/install_test.go
+++ b/internal/cli/kubernetes/operator/install_test.go
@@ -12,6 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package operator

--- a/internal/kubernetes/operator/config_exporter_test.go
+++ b/internal/kubernetes/operator/config_exporter_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package operator
 

--- a/internal/kubernetes/operator/dbusers/dbusers_test.go
+++ b/internal/kubernetes/operator/dbusers/dbusers_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package dbusers
 

--- a/internal/kubernetes/operator/deployment/deployment_test.go
+++ b/internal/kubernetes/operator/deployment/deployment_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package deployment
 

--- a/internal/kubernetes/operator/project/containers_test.go
+++ b/internal/kubernetes/operator/project/containers_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/project/customroles_test.go
+++ b/internal/kubernetes/operator/project/customroles_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 //nolint:all
 package project

--- a/internal/kubernetes/operator/project/integrations_test.go
+++ b/internal/kubernetes/operator/project/integrations_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/project/ipaccesslist_test.go
+++ b/internal/kubernetes/operator/project/ipaccesslist_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/project/peerings_test.go
+++ b/internal/kubernetes/operator/project/peerings_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/project/privateendpoints_test.go
+++ b/internal/kubernetes/operator/project/privateendpoints_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/project/project_test.go
+++ b/internal/kubernetes/operator/project/project_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package project
 

--- a/internal/kubernetes/operator/resources/normalizer_test.go
+++ b/internal/kubernetes/operator/resources/normalizer_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package resources
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package store
 

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build unit
 
 package validate
 

--- a/test/e2e/atlas_e2e_test_generator_test.go
+++ b/test/e2e/atlas_e2e_test_generator_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || install || generate || apply
 
 package e2e
 

--- a/test/e2e/cli.go
+++ b/test/e2e/cli.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || cli || install || generate || apply
 
 package e2e
 

--- a/test/e2e/cli_test.go
+++ b/test/e2e/cli_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || cli
 
 package e2e
 

--- a/test/e2e/helper_test.go
+++ b/test/e2e/helper_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || install || generate || apply
 
 package e2e
 

--- a/test/e2e/kubernetes_config_apply_test.go
+++ b/test/e2e/kubernetes_config_apply_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || apply
 
 package e2e
 

--- a/test/e2e/kubernetes_config_generate_test.go
+++ b/test/e2e/kubernetes_config_generate_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || generate
 
 package e2e
 

--- a/test/e2e/kubernetes_operator_install_test.go
+++ b/test/e2e/kubernetes_operator_install_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || install
 
 package e2e
 

--- a/test/e2e/kubernetes_test.go
+++ b/test/e2e/kubernetes_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build e2e || apply || generate || install
 
 package e2e
 

--- a/test/e2e/operator_helper_test.go
+++ b/test/e2e/operator_helper_test.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//go:build e2e || install || generate || apply
 
 package e2e
 


### PR DESCRIPTION
## Proposed changes
Remove go build tags for unit and e2e tests and run tests by their names

- [x] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added any necessary documentation in the document requirements section listed in [CONTRIBUTING.md](https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md) (if appropriate)
- [x] I have addressed the @mongodb/docs-cloud-team comments (if appropriate)
- [x] I have run `make fmt` and formatted my code

## Further comments

Experimental. Do not merge for now