### PR TITLE
Go bump to fix govunlcheck and other check issues

### DIFF
--- a/.github/workflows/code-health.yml
+++ b/.github/workflows/code-health.yml
@@ -21,11 +21,8 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-          cache: false # see https://github.com/golangci/golangci-lint-action/issues/807
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7.0.0
-        with:
-          args: --timeout 3m0s
+      - name: Install & Run golangci-lint
+        run: make devtools lint
   govulncheck:
     name: govulncheck
     runs-on: ubuntu-latest
@@ -222,4 +219,4 @@ jobs:
           go-version-file: 'go.mod'
       - run: go install gotest.tools/gotestsum@latest
       - run: make fuzz-normalizer-test
-  
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # A Self-Documenting Makefile: http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 
 GOCOVERDIR?=$(abspath cov)
-GOLANGCI_VERSION?=latest
+GOLANGCI_VERSION?=v2.11.0
 
 PLUGIN_SOURCE_FILES?=./cmd/plugin
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ fmt: ## Format changed go
 
 .PHONY: lint
 lint: ## Run linter
-	golangci-lint run
+	golangci-lint run --timeout 3m0s
 
 .PHONY: govulncheck
 govulncheck: ## Run govulncheck for known vulnerabilities

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mongodb/atlas-cli-plugin-kubernetes
 
-go 1.25.9
+go 1.26.2
 
 require (
 	cloud.google.com/go/compute v1.60.0


### PR DESCRIPTION
<!--
Thanks for contributing to Atlas CLI Kubernetes Plugin!

Before you submit your pull request, please review our contribution guidelines:
https://github.com/mongodb/atlas-cli-plugin-kubernetes/blob/master/CONTRIBUTING.md

Please fill out the information below to help speed up the review process
and get you pull request merged!
-->

## Proposed changes

Govulncheck is flagging this code as vulnerable due to Go1.26.1 being used, even though 1.25.9 is not vulnerable. The easiest solution is to bump already to 1.26, which is something we were going to do sooner rather than later anyways.

Merging this might help solve some of the bumps stuck right now.

Also:
- Unpin `golangci-lint` to avoid some version download error.
- Fix `lint`. 

## Checklist

<!--
Check the boxes that apply. If you're unsure about any of them, don't hesitate to ask!
We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have signed the [MongoDB CLA](https://www.mongodb.com/legal/contributor-agreement)
- [X] I have run `make fmt` and formatted my code

